### PR TITLE
Patch to optimization_algorithm_levenberg.cpp

### DIFF
--- a/g2o/core/optimization_algorithm_levenberg.cpp
+++ b/g2o/core/optimization_algorithm_levenberg.cpp
@@ -86,6 +86,7 @@ namespace g2o {
     // core part of the Levenbarg algorithm
     if (iteration == 0) {
       _currentLambda = computeLambdaInit();
+      _ni = 2;
     }
 
     double rho=0;
@@ -155,7 +156,7 @@ namespace g2o {
       assert(v);
       int dim = v->dimension();
       for (int j = 0; j < dim; ++j){
-        maxDiagonal = std::max(fabs(v->hessian(j,j)),maxDiagonal); 
+        maxDiagonal = std::max(fabs(v->hessian(j,j)),maxDiagonal);
       }
     }
     return _tau*maxDiagonal;


### PR DESCRIPTION
Fixed bug where _ni was not being reset.

Near a global minima it is possible to find a constraint configuration where LM fails to make any good steps (rho<0)
In this case _currentLambda is scaled by _ni, and _ni*=2.
After repeated bad steps both _currentLambda and _ni are increased exponentially.
Normally on the next good step _ni is reset back to 2.
However a good step may not occur before _ni becomes "too large" and the solve() iteration finishes.
On the next call to solve() you reset _currentLambda back to the initial value (line 88). However _ni remains at the previous large value.
Have checked both SPA2d, and the stable version of G2O (graph_optimizer_sparse.cpp, line 346) and in both cases the _ni value is reset back to 2.0 on the first iteration of each solve().
