### PR TITLE
Fix for SparseOptimizer::clear.

### DIFF
--- a/g2o/core/sparse_optimizer.cpp
+++ b/g2o/core/sparse_optimizer.cpp
@@ -484,7 +484,7 @@ namespace g2o{
     _ivMap.clear();
     _activeVertices.clear();
     _activeEdges.clear();
-    HyperGraph::clear();
+    OptimizableGraph::clear();
   }
 
   SparseOptimizer::VertexContainer::const_iterator SparseOptimizer::findActiveVertex(const OptimizableGraph::Vertex* v) const


### PR DESCRIPTION
Please double check that this is whatWeWant TM.
- Call OptimizableGraph::clear instead of HyperGraph::clear. The former calls
  the latter, but also calls _parameters.clear(), which is currently not
  invoked by OptimizableGraph::clear.
