### PR TITLE
Various fixes for MSVC with backward support for VC10.0

### DIFF
--- a/g2o/apps/g2o_hierarchical/CMakeLists.txt
+++ b/g2o/apps/g2o_hierarchical/CMakeLists.txt
@@ -6,6 +6,13 @@ ADD_LIBRARY(g2o_hierarchical_library ${G2O_LIB_TYPE}
   backbone_tree_action.cpp
   simple_star_ops.cpp
   g2o_hierarchical_test_functions.cpp
+  edge_labeler.h
+  edge_creator.h
+  star.h
+  edge_types_cost_function.h
+  backbone_tree_action.h
+  simple_star_ops.h
+  g2o_hierarchical_api.h
 )
 
 

--- a/g2o/apps/g2o_hierarchical/edge_creator.h
+++ b/g2o/apps/g2o_hierarchical/edge_creator.h
@@ -5,6 +5,8 @@
 #include <Eigen/Core>
 #include <vector>
 
+#include "g2o_hierarchical_api.h"
+
 namespace g2o {
 
   /**
@@ -15,7 +17,7 @@ namespace g2o {
    * matters.  This class is heavily based on the Factory, and utilizes strings
    * to identify the edge types.
    */
-struct EdgeCreator{
+struct G2O_HIERARCHICAL_API EdgeCreator{
   struct EdgeCreatorEntry {
     EdgeCreatorEntry(const std::string& edgeTypeName, const std::vector<int>& parameterIds)
     :_edgeTypeName(edgeTypeName), _parameterIds(parameterIds) {}

--- a/g2o/apps/g2o_hierarchical/edge_labeler.h
+++ b/g2o/apps/g2o_hierarchical/edge_labeler.h
@@ -4,6 +4,8 @@
 #include "g2o/core/sparse_optimizer.h"
 #include <Eigen/Core>
 
+#include "g2o_hierarchical_api.h"
+
 namespace g2o {
   /**
    * This class implements the functions to label an edge (measurement) based
@@ -15,7 +17,7 @@ namespace g2o {
    * <li> projecting the sigma points in the error space, and thus computing the information matrix of the labeled edge
    * </ul>
    */
-struct EdgeLabeler{
+struct G2O_HIERARCHICAL_API EdgeLabeler{
   //! constructs an edge labeler that operates on the optimizer passed as argument
   //! @param optimizer: the optimizer
   EdgeLabeler(SparseOptimizer* optimizer);

--- a/g2o/apps/g2o_hierarchical/g2o_hierarchical_api.h
+++ b/g2o/apps/g2o_hierarchical/g2o_hierarchical_api.h
@@ -1,19 +1,3 @@
-// g2o - General Graph Optimization
-// Copyright (C) 2015 Hamdi Sahloul
-// 
-// g2o is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published
-// by the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// 
-// g2o is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Lesser General Public License for more details.
-// 
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 #ifndef G2O_HIERARCHICAL_API_H
 #define G2O_HIERARCHICAL_API_H
 
@@ -21,7 +5,7 @@
 
 #ifdef _MSC_VER
 // We are using a Microsoft compiler:
-#ifdef G2O_LGPL_SHARED_LIBS
+#ifdef G2O_SHARED_LIBS
 #ifdef g2o_hierarchical_library_EXPORTS
 #define G2O_HIERARCHICAL_API __declspec(dllexport)
 #else

--- a/g2o/apps/g2o_hierarchical/g2o_hierarchical_api.h
+++ b/g2o/apps/g2o_hierarchical/g2o_hierarchical_api.h
@@ -1,0 +1,39 @@
+// g2o - General Graph Optimization
+// Copyright (C) 2015 Hamdi Sahloul
+// 
+// g2o is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// g2o is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef G2O_HIERARCHICAL_API_H
+#define G2O_HIERARCHICAL_API_H
+
+#include "g2o/config.h"
+
+#ifdef _MSC_VER
+// We are using a Microsoft compiler:
+#ifdef G2O_LGPL_SHARED_LIBS
+#ifdef g2o_hierarchical_library_EXPORTS
+#define G2O_HIERARCHICAL_API __declspec(dllexport)
+#else
+#define G2O_HIERARCHICAL_API __declspec(dllimport)
+#endif
+#else
+#define G2O_HIERARCHICAL_API
+#endif
+
+#else
+// Not Microsoft compiler so set empty definition:
+#define G2O_HIERARCHICAL_API
+#endif
+
+#endif // G2O_CSPARSE_API_H

--- a/g2o/apps/g2o_hierarchical/simple_star_ops.h
+++ b/g2o/apps/g2o_hierarchical/simple_star_ops.h
@@ -9,11 +9,12 @@
 #include "edge_creator.h"
 #include "edge_labeler.h"
 
+#include "g2o_hierarchical_api.h"
 
 namespace g2o {
 
 
-  void constructEdgeStarMap(EdgeStarMap& esmap, StarSet& stars, bool low=true);
+  G2O_HIERARCHICAL_API void constructEdgeStarMap(EdgeStarMap& esmap, StarSet& stars, bool low=true);
 
   size_t vertexEdgesInStar(HyperGraph::EdgeSet& eset, HyperGraph::Vertex* v, Star* s, EdgeStarMap& esmap);
 
@@ -21,9 +22,9 @@ namespace g2o {
 
   void assignHierarchicalEdges(StarSet& stars, EdgeStarMap& esmap, EdgeLabeler* labeler, EdgeCreator* creator, SparseOptimizer* optimizer, int minNumEdges, int maxIterations);
 
-  void computeBorder(StarSet& stars, EdgeStarMap& hesmap);
+  G2O_HIERARCHICAL_API void computeBorder(StarSet& stars, EdgeStarMap& hesmap);
 
-  void computeSimpleStars(StarSet& stars,
+  G2O_HIERARCHICAL_API void computeSimpleStars(StarSet& stars,
                           SparseOptimizer* optimizer,
                           EdgeLabeler* labeler,
                           EdgeCreator* creator,

--- a/g2o/apps/g2o_simulator/simutils.h
+++ b/g2o/apps/g2o_simulator/simutils.h
@@ -38,13 +38,13 @@ namespace g2o {
   // 2: inside
   // 3: all clipped
 
-  int clipSegmentCircle(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double r);
+  G2O_SIMULATOR_API int clipSegmentCircle(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double r);
 
   // -1: outside
   // 0: p1Clipped
   // 1: p2clipped
   // 2: inside
-  int clipSegmentLine(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double a, double b, double c );
+  G2O_SIMULATOR_API int clipSegmentLine(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double a, double b, double c );
   
 
   // -1: outside
@@ -52,10 +52,10 @@ namespace g2o {
   // 1: p2clipped
   // 2: inside
   // 3: all clipped
-  int clipSegmentFov(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double min, double max);
+  G2O_SIMULATOR_API int clipSegmentFov(Eigen::Vector2d& p1, Eigen::Vector2d& p2, double min, double max);
 
   
-  Eigen::Vector2d computeLineParameters(const Eigen::Vector2d& p1, const Eigen::Vector2d& p2);
+  G2O_SIMULATOR_API Eigen::Vector2d computeLineParameters(const Eigen::Vector2d& p1, const Eigen::Vector2d& p2);
 }
 
 #endif

--- a/g2o/examples/plane_slam/simulator_3d_plane.cpp
+++ b/g2o/examples/plane_slam/simulator_3d_plane.cpp
@@ -17,7 +17,7 @@ using namespace Eigen;
 
 G2O_USE_OPTIMIZATION_LIBRARY(csparse)
 
-typedef Eigen::Matrix<double, 6,6> Matrix6d;
+//typedef Eigen::Matrix<double, 6,6> Matrix6d; //Avoid ambiguous symbol
 
 double uniform_rand(double lowerBndr, double upperBndr)
 {

--- a/g2o/types/slam2d_addons/edge_line2d_pointxy.h
+++ b/g2o/types/slam2d_addons/edge_line2d_pointxy.h
@@ -36,13 +36,13 @@
 
 namespace g2o {
 
-  class G2O_TYPES_SLAM2D_ADDONS_API EdgeLine2DPointXY : public BaseBinaryEdge<1, double, VertexLine2D, VertexPointXY>
+  class EdgeLine2DPointXY : public BaseBinaryEdge<1, double, VertexLine2D, VertexPointXY> //Avoid redefinition of BaseEdge in MSVC
   {
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      EdgeLine2DPointXY();
+      G2O_TYPES_SLAM2D_ADDONS_API EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      G2O_TYPES_SLAM2D_ADDONS_API EdgeLine2DPointXY();
 
-      void computeError()
+      G2O_TYPES_SLAM2D_ADDONS_API void computeError()
       {
         const VertexLine2D* l = static_cast<const VertexLine2D*>(_vertices[0]);
         const VertexPointXY* p = static_cast<const VertexPointXY*>(_vertices[1]);
@@ -51,19 +51,19 @@ namespace g2o {
         _error[0] =  prediction - _measurement;
       }
 
-      virtual bool setMeasurementData(const double* d){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementData(const double* d){
 	_measurement = *d;
         return true;
       }
 
-      virtual bool getMeasurementData(double* d) const{
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool getMeasurementData(double* d) const{
         *d = _measurement;
         return true;
       }
 
-      virtual int measurementDimension() const {return 1;}
+      G2O_TYPES_SLAM2D_ADDONS_API virtual int measurementDimension() const {return 1;}
 
-      virtual bool setMeasurementFromState(){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementFromState(){
         const VertexLine2D* l = static_cast<const VertexLine2D*>(_vertices[0]);
         const VertexPointXY* p = static_cast<const VertexPointXY*>(_vertices[1]);
         Vector2D n(cos(l->theta()), sin(l->theta()));
@@ -72,8 +72,8 @@ namespace g2o {
         return true;
       }
 
-      virtual bool read(std::istream& is);
-      virtual bool write(std::ostream& os) const;
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool read(std::istream& is);
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool write(std::ostream& os) const;
 
       /* virtual void initialEstimate(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to); */
       /* virtual double initialEstimatePossible(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to) { (void) to; return (from.count(_vertices[0]) == 1 ? 1.0 : -1.0);} */

--- a/g2o/types/slam2d_addons/edge_se2_segment2d.h
+++ b/g2o/types/slam2d_addons/edge_se2_segment2d.h
@@ -35,18 +35,18 @@
 
 namespace g2o {
 
-  class G2O_TYPES_SLAM2D_ADDONS_API EdgeSE2Segment2D : public BaseBinaryEdge<4, Vector4D, VertexSE2, VertexSegment2D>
+  class EdgeSE2Segment2D : public BaseBinaryEdge<4, Vector4D, VertexSE2, VertexSegment2D> //Avoid redefinition of BaseEdge in MSVC
   {
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      EdgeSE2Segment2D();
+      G2O_TYPES_SLAM2D_ADDONS_API EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      G2O_TYPES_SLAM2D_ADDONS_API EdgeSE2Segment2D();
 
-      Vector2D measurementP1(){ return Eigen::Map<const Vector2D>(&(_measurement[0])); }
-      Vector2D measurementP2(){ return Eigen::Map<const Vector2D>(&(_measurement[2])); }
-      void  setMeasurementP1(const Vector2D& p1){ Eigen::Map<Vector2D> v(&_measurement[0]); v=p1; }
-      void  setMeasurementP2(const Vector2D& p2){ Eigen::Map<Vector2D> v(&_measurement[2]); v=p2; }
+      G2O_TYPES_SLAM2D_ADDONS_API Vector2D measurementP1(){ return Eigen::Map<const Vector2D>(&(_measurement[0])); }
+      G2O_TYPES_SLAM2D_ADDONS_API Vector2D measurementP2(){ return Eigen::Map<const Vector2D>(&(_measurement[2])); }
+      G2O_TYPES_SLAM2D_ADDONS_API void  setMeasurementP1(const Vector2D& p1){ Eigen::Map<Vector2D> v(&_measurement[0]); v=p1; }
+      G2O_TYPES_SLAM2D_ADDONS_API void  setMeasurementP2(const Vector2D& p2){ Eigen::Map<Vector2D> v(&_measurement[2]); v=p2; }
 
-      void computeError()
+      G2O_TYPES_SLAM2D_ADDONS_API void computeError()
       {
         const VertexSE2* v1 = static_cast<const VertexSE2*>(_vertices[0]);
         const VertexSegment2D* l2 = static_cast<const VertexSegment2D*>(_vertices[1]);
@@ -58,21 +58,21 @@ namespace g2o {
 	_error = _error - _measurement;
       }
 
-      virtual bool setMeasurementData(const double* d){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementData(const double* d){
         Eigen::Map<const Vector4D> data(d);
 	_measurement = data;
 	return true;
       }
 
-      virtual bool getMeasurementData(double* d) const{
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool getMeasurementData(double* d) const{
         Eigen::Map<Vector4D> data(d);
 	data = _measurement;
 	return true;
       }
 
-      virtual int measurementDimension() const {return 4;}
+      G2O_TYPES_SLAM2D_ADDONS_API virtual int measurementDimension() const {return 4;}
 
-      virtual bool setMeasurementFromState(){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementFromState(){
         const VertexSE2* v1 = static_cast<const VertexSE2*>(_vertices[0]);
         const VertexSegment2D* l2 = static_cast<const VertexSegment2D*>(_vertices[1]);
         SE2 iEst=v1->estimate().inverse();
@@ -81,11 +81,11 @@ namespace g2o {
 	return true;
       }
 
-      virtual bool read(std::istream& is);
-      virtual bool write(std::ostream& os) const;
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool read(std::istream& is);
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool write(std::ostream& os) const;
 
-      virtual void initialEstimate(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to);
-      virtual double initialEstimatePossible(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to) { (void) to; return (from.count(_vertices[0]) == 1 ? 1.0 : -1.0);}
+      G2O_TYPES_SLAM2D_ADDONS_API virtual void initialEstimate(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to);
+      G2O_TYPES_SLAM2D_ADDONS_API virtual double initialEstimatePossible(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* to) { (void) to; return (from.count(_vertices[0]) == 1 ? 1.0 : -1.0);}
 /* #ifndef NUMERIC_JACOBIAN_TWO_D_TYPES */
 /*       virtual void linearizeOplus(); */
 /* #endif */

--- a/g2o/types/slam2d_addons/edge_se2_segment2d_line.h
+++ b/g2o/types/slam2d_addons/edge_se2_segment2d_line.h
@@ -35,20 +35,20 @@
 
 namespace g2o {
 
-  class G2O_TYPES_SLAM2D_ADDONS_API EdgeSE2Segment2DLine : public BaseBinaryEdge<2, Vector2D, VertexSE2, VertexSegment2D>
+  class EdgeSE2Segment2DLine : public BaseBinaryEdge<2, Vector2D, VertexSE2, VertexSegment2D> //Avoid redefinition of BaseEdge in MSVC
   {
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      EdgeSE2Segment2DLine();
+      G2O_TYPES_SLAM2D_ADDONS_API EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      G2O_TYPES_SLAM2D_ADDONS_API EdgeSE2Segment2DLine();
 
-      double theta() const {return _measurement[0];}
-      double rho()   const {return _measurement[1];}
+      G2O_TYPES_SLAM2D_ADDONS_API double theta() const {return _measurement[0];}
+      G2O_TYPES_SLAM2D_ADDONS_API double rho()   const {return _measurement[1];}
 
-      void   setTheta( double t)  {_measurement[0] = t;}
-      void   setRho( double r)    {_measurement[1] = r;}
+      G2O_TYPES_SLAM2D_ADDONS_API void   setTheta( double t)  {_measurement[0] = t;}
+      G2O_TYPES_SLAM2D_ADDONS_API void   setRho( double r)    {_measurement[1] = r;}
 
 
-      void computeError()
+      G2O_TYPES_SLAM2D_ADDONS_API void computeError()
       {
         const VertexSE2* v1 = static_cast<const VertexSE2*>(_vertices[0]);
         const VertexSegment2D* l2 = static_cast<const VertexSegment2D*>(_vertices[1]);
@@ -64,21 +64,21 @@ namespace g2o {
         _error[0]=normalize_theta(_error[0]);
       }
 
-      virtual bool setMeasurementData(const double* d){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementData(const double* d){
         Eigen::Map<const Vector2D> data(d);
 	_measurement = data;
 	return true;
       }
 
-      virtual bool getMeasurementData(double* d) const{
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool getMeasurementData(double* d) const{
         Eigen::Map<Vector2D> data(d);
 	data = _measurement;
 	return true;
       }
 
-      virtual int measurementDimension() const {return 2;}
+      G2O_TYPES_SLAM2D_ADDONS_API virtual int measurementDimension() const {return 2;}
 
-      virtual bool setMeasurementFromState(){
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool setMeasurementFromState(){
      const VertexSE2* v1 = static_cast<const VertexSE2*>(_vertices[0]);
         const VertexSegment2D* l2 = static_cast<const VertexSegment2D*>(_vertices[1]);
         SE2 iEst=v1->estimate().inverse();
@@ -92,8 +92,8 @@ namespace g2o {
 	return true;
       }
 
-      virtual bool read(std::istream& is);
-      virtual bool write(std::ostream& os) const;
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool read(std::istream& is);
+      G2O_TYPES_SLAM2D_ADDONS_API virtual bool write(std::ostream& os) const;
 
 
 /* #ifndef NUMERIC_JACOBIAN_TWO_D_TYPES */

--- a/g2o/types/slam3d/vertex_se3.h
+++ b/g2o/types/slam3d/vertex_se3.h
@@ -136,7 +136,7 @@ namespace g2o {
   /**
    * \brief visualize the 3D pose vertex
    */
-  class VertexSE3DrawAction: public DrawAction{
+  class G2O_TYPES_SLAM3D_API VertexSE3DrawAction: public DrawAction{
     public:
       VertexSE3DrawAction();
       virtual HyperGraphElementAction* operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_);

--- a/g2o/types/slam3d_addons/edge_se3_calib.h
+++ b/g2o/types/slam3d_addons/edge_se3_calib.h
@@ -38,15 +38,15 @@ namespace g2o
   /**
    * \brief Landmark measurement that also calibrates an offset for the landmark measurement
    */
-  class G2O_TYPES_SLAM3D_ADDONS_API EdgeSE3Calib : public BaseMultiEdge<6, Isometry3D>
+  class EdgeSE3Calib : public BaseMultiEdge<6, Isometry3D> //Avoid redefinition of BaseEdge in MSVC
   {
     public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-      EdgeSE3Calib();
+      G2O_TYPES_SLAM3D_ADDONS_API EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+      G2O_TYPES_SLAM3D_ADDONS_API EdgeSE3Calib();
 
-      void computeError();
-      virtual bool read(std::istream& is);
-      virtual bool write(std::ostream& os) const;
+      G2O_TYPES_SLAM3D_ADDONS_API void computeError();
+      G2O_TYPES_SLAM3D_ADDONS_API virtual bool read(std::istream& is);
+      G2O_TYPES_SLAM3D_ADDONS_API virtual bool write(std::ostream& os) const;
   };
 
 } // end namespace

--- a/g2o/types/slam3d_addons/edge_se3_plane_calib.h
+++ b/g2o/types/slam3d_addons/edge_se3_plane_calib.h
@@ -39,10 +39,10 @@ namespace g2o {
   };
 
 #ifdef G2O_HAVE_OPENGL
-  class G2O_TYPES_SLAM3D_ADDONS_API EdgeSE3PlaneSensorCalibDrawAction: public DrawAction{
+  class EdgeSE3PlaneSensorCalibDrawAction: public DrawAction{
   public:
-    EdgeSE3PlaneSensorCalibDrawAction();
-    virtual HyperGraphElementAction* operator()(HyperGraph::HyperGraphElement* element,
+    G2O_TYPES_SLAM3D_ADDONS_API EdgeSE3PlaneSensorCalibDrawAction();
+    G2O_TYPES_SLAM3D_ADDONS_API virtual HyperGraphElementAction* operator()(HyperGraph::HyperGraphElement* element,
             HyperGraphElementAction::Parameters* params_ );
   protected:
     virtual bool refreshPropertyPtrs(HyperGraphElementAction::Parameters* params_);

--- a/g2o/types/slam3d_addons/line3d.h
+++ b/g2o/types/slam3d_addons/line3d.h
@@ -14,38 +14,38 @@ namespace g2o {
 
   typedef Eigen::Matrix<double, 6, 6, Eigen::ColMajor> Matrix6d;
 
-
-  class G2O_TYPES_SLAM3D_ADDONS_API Line3D : public Vector6d{
+  /*Using G2O_TYPES_SLAM3D_ADDONS_API here causes Compiler Error C2487 on MSVC*/
+  class Line3D : public Vector6d{
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
-      friend Line3D operator*(const Isometry3D& t, const Line3D& line);
+      G2O_TYPES_SLAM3D_ADDONS_API friend Line3D operator*(const Isometry3D& t, const Line3D& line);
       Line3D(){
         *this << 0., 0., 0., 1., 0., 0.;
       }
 
-      Line3D(const Vector6d& v){
+      G2O_TYPES_SLAM3D_ADDONS_API Line3D(const Vector6d& v){
         (Vector6d&)*this = v;
       }
 
-      Vector6d toCartesian() const;
+      G2O_TYPES_SLAM3D_ADDONS_API Vector6d toCartesian() const;
 
-      inline Vector3D w() const {
+      G2O_TYPES_SLAM3D_ADDONS_API inline Vector3D w() const {
 	return head<3>();
       }
 
-      inline Vector3D d() const {
+      G2O_TYPES_SLAM3D_ADDONS_API inline Vector3D d() const {
 	return tail<3>();
       }
 
-      inline void setW(const Vector3D& w_)  {
+      G2O_TYPES_SLAM3D_ADDONS_API inline void setW(const Vector3D& w_)  {
 	head<3>()=w_;
       }
 
-      inline void setD(const Vector3D& d_)  {
+      G2O_TYPES_SLAM3D_ADDONS_API inline void setD(const Vector3D& d_)  {
 	tail<3>()=d_;
       }
 
-      static inline Line3D fromCartesian(const Vector6d& cart) {
+      G2O_TYPES_SLAM3D_ADDONS_API static inline Line3D fromCartesian(const Vector6d& cart) {
 	Line3D l;
 	Vector3D _d= cart.tail<3>() * 1./cart.tail<3>().norm();
 	Vector3D _p= cart.head<3>();
@@ -55,34 +55,34 @@ namespace g2o {
 	return l;
       }
 
-      inline void normalize() {
+      G2O_TYPES_SLAM3D_ADDONS_API inline void normalize() {
 	double n = 1./d().norm();
 	(*this)*=n;
       }
 
-      inline Line3D normalized() const {
+      G2O_TYPES_SLAM3D_ADDONS_API inline Line3D normalized() const {
 	return  Line3D((Vector6d)(*this)*(1./d().norm()));
       }
 
-      inline void oplus(Vector6d v){
+      G2O_TYPES_SLAM3D_ADDONS_API inline void oplus(Vector6d v){
 	*this+=v;
 	normalize();
       }
 
-      inline Vector6d ominus(const Line3D& line){
+      G2O_TYPES_SLAM3D_ADDONS_API inline Vector6d ominus(const Line3D& line){
 	return (Vector6d)(*this)-line;
       }
 
-      static void jacobian(Matrix7x6d& Jp, Matrix7x6d& Jl, const Isometry3D& x, const Line3D& l);
+      G2O_TYPES_SLAM3D_ADDONS_API static void jacobian(Matrix7x6d& Jp, Matrix7x6d& Jl, const Isometry3D& x, const Line3D& l);
   };
 
 
 
-  Line3D operator*(const Isometry3D& t, const Line3D& line);
+  G2O_TYPES_SLAM3D_ADDONS_API Line3D operator*(const Isometry3D& t, const Line3D& line);
 
   namespace internal {
-    Vector6d transformCartesianLine(const Isometry3D& t, const Vector6d& line);
-    Vector6d normalizeCartesianLine(const Vector6d& line);
+    G2O_TYPES_SLAM3D_ADDONS_API Vector6d transformCartesianLine(const Isometry3D& t, const Vector6d& line);
+    G2O_TYPES_SLAM3D_ADDONS_API Vector6d normalizeCartesianLine(const Vector6d& line);
   }
 
 }


### PR DESCRIPTION
Microsoft Visual C++ 2010
- Solving MSVC fatal errors LNK1169 (still having one error with types_slam3d_addons)
- Solving MSVC fatal errors C2487
- Enabling g2o_hierarchical library dllexport

There was about 8 projects unable to build under MSVC2010, now only one remaining!
I will push another merge request once I solve it.