### PR TITLE
Sim3 normalization rotation

### DIFF
--- a/g2o/types/sim3/sim3.h
+++ b/g2o/types/sim3/sim3.h
@@ -55,11 +55,13 @@ namespace g2o
       Sim3(const Eigen::Quaterniond & r, const Eigen::Vector3d & t, double s)
         : r(r),t(t),s(s)
       {
+			normalizeRotation();
       }
 
       Sim3(const Eigen::Matrix3d & R, const Eigen::Vector3d & t, double s)
         : r(Eigen::Quaterniond(R)),t(t),s(s)
       {
+			normalizeRotation();
       }
 
 
@@ -260,7 +262,12 @@ namespace g2o
         *this=ret;
         return *this;
       }
-
+    void normalizeRotation(){
+        if (r.w()<0){
+          r.coeffs() *= -1;
+        }
+        r.normalize();
+    }
       inline const Eigen::Vector3d& translation() const {return t;}
 
       inline Eigen::Vector3d& translation() {return t;}


### PR DESCRIPTION
Hi, 
I was working with the sim3 library, and this simple example fails: 
  
 double s = 1;
 Vector3d t(-3.8422,1.4232,1.0629);
 Eigen::Quaterniond q(0.1259, -0.4943,	0.8317,-0.2192);
 g2o::Sim3 pose_initial(q,t,s);
 g2o::Sim3 pose_inv, pose_final; 
 pose_inv = pose_initial.inverse();
 pose_final = pose_inv.inverse(); 

pose_initial and pose_final should be equal, but they are not.

This pull request is to add a normalization in the rotation, which solves the problem. I copied this normalization from the se3 library.  

Thanks, 
Marta