### PR TITLE
MSVC linker: fix duplicated symbols in debug (Fixes #66)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,16 @@ IF(WIN32)
     ADD_DEFINITIONS(-DNOMINMAX)
     ADD_DEFINITIONS(-D_USE_MATH_DEFINES)
     # SSE2 optimizations
-    ADD_DEFINITIONS("/arch:SSE2")
+	if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)  # No need to specify if building for x64 (actually, it generates an annoying warning)
+		ADD_DEFINITIONS("/arch:SSE2")
+	endif()
     IF (BUILD_SHARED_LIBS)
       # disable warning on missing DLL interfaces
       ADD_DEFINITIONS("/wd4251")
     ENDIF()
+	# Fix issue: https://github.com/RainerKuemmerle/g2o/issues/66
+	#            Link error LNK2005 due to duplicated symbols
+	add_definitions("/Ob2")	
   ENDIF(MSVC)
 ELSEIF(CYGWIN)
   MESSAGE(STATUS "Compiling on Cygwin")


### PR DESCRIPTION
Hi @RainerKuemmerle, this is a really small change. 

Congrats for your great library!
