### PR TITLE
Fix operator< for CacheKey

### DIFF
--- a/g2o/core/cache.cpp
+++ b/g2o/core/cache.cpp
@@ -51,6 +51,8 @@ namespace g2o {
   bool Cache::CacheKey::operator<(const Cache::CacheKey& c) const{
     if (_type < c._type)
       return true;
+    else if (c._type < _type)
+      return false;
     return std::lexicographical_compare (_parameters.begin( ), _parameters.end( ),
            c._parameters.begin( ), c._parameters.end( ) );
   }


### PR DESCRIPTION
This is a fix for the issue #103.
When comparing CacheKey with operator< we have to use lexicographical sort by parameters only if CacheKey::_type is equal. If CacheKey::_type is not equal, we make decision using only it.