### PR TITLE
[core] fix the memory leak

### DIFF
--- a/g2o/core/block_solver.hpp
+++ b/g2o/core/block_solver.hpp
@@ -232,8 +232,10 @@ bool BlockSolver<Traits>::buildStructure(bool zeroBlocks)
     }
   }
 
-  if (! _doSchur)
+  if (! _doSchur) {
+    delete schurMatrixLookup;
     return true;
+  }
 
   _DInvSchur->diagonal().resize(landmarkIdx);
   _Hpl->fillSparseBlockMatrixCCS(*_HplCCS);


### PR DESCRIPTION
Greetings @RainerKuemmerle,

On line number `236` of [block_solver.hpp](https://github.com/RainerKuemmerle/g2o/blob/master/g2o/core/block_solver.hpp#L236) there is a memory leak, which is a lil' bug.

The reason we should delete is that memory is a finite resource within our running programs. Sure in very short running simple programs, failing to delete memory won't have a noticeable effect. However on long running programs, failing to delete memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must delete memory.