### PR TITLE
Add ubuntu 16.04 name for libqglviewer

### DIFF
--- a/cmake_modules/FindQGLViewer.cmake
+++ b/cmake_modules/FindQGLViewer.cmake
@@ -19,7 +19,7 @@ FIND_PATH(QGLVIEWER_INCLUDE_DIR qglviewer.h
   )
 
 find_library(QGLVIEWER_LIBRARY_RELEASE
-  NAMES qglviewer-qt4 qglviewer QGLViewer QGLViewer2
+  NAMES qglviewer-qt4 QGLViewer-qt4 qglviewer QGLViewer QGLViewer2
   PATHS /usr/lib
         /usr/local/lib
         /opt/local/lib


### PR DESCRIPTION
On Ubuntu 16.04 libqglviewer-qt4 is called libQGLViewer-qt4.