### PR TITLE
Early termination of Levenberg-Marquardt in the case of infinite damping

### DIFF
--- a/g2o/core/optimization_algorithm_levenberg.cpp
+++ b/g2o/core/optimization_algorithm_levenberg.cpp
@@ -137,11 +137,13 @@ namespace g2o {
         _currentLambda*=_ni;
         _ni*=2;
         _optimizer->pop(); // restore the last state before trying to optimize
+        if (!g2o_isfinite(_currentLambda))
+          break;
       }
       qmax++;
     } while (rho<0 && qmax < _maxTrialsAfterFailure->value() && ! _optimizer->terminate());
 
-    if (qmax == _maxTrialsAfterFailure->value() || rho==0)
+    if (qmax == _maxTrialsAfterFailure->value() || rho==0 || !g2o_isfinite(_currentLambda))
       return Terminate;
     return OK;
   }


### PR DESCRIPTION
If damping factor becomes infinite (i.e. we are unable to make even a very small "gradient descent style" step), there is no point to continue calculations (because linear solver will be unable to solve damped linear system).