### PR TITLE
Fix support for dynamic dimensionality of edges

### DIFF
--- a/g2o/core/base_binary_edge.hpp
+++ b/g2o/core/base_binary_edge.hpp
@@ -131,8 +131,8 @@ void BaseBinaryEdge<D, E, VertexXiType, VertexXjType>::constructQuadraticForm()
 template <int D, typename E, typename VertexXiType, typename VertexXjType>
 void BaseBinaryEdge<D, E, VertexXiType, VertexXjType>::linearizeOplus(JacobianWorkspace& jacobianWorkspace)
 {
-  new (&_jacobianOplusXi) JacobianXiOplusType(jacobianWorkspace.workspaceForVertex(0), D, Di);
-  new (&_jacobianOplusXj) JacobianXjOplusType(jacobianWorkspace.workspaceForVertex(1), D, Dj);
+  new (&_jacobianOplusXi) JacobianXiOplusType(jacobianWorkspace.workspaceForVertex(0), D < 0 ? _dimension : D, Di);
+  new (&_jacobianOplusXj) JacobianXjOplusType(jacobianWorkspace.workspaceForVertex(1), D < 0 ? _dimension : D, Dj);
   linearizeOplus();
 }
 

--- a/g2o/core/base_multi_edge.hpp
+++ b/g2o/core/base_multi_edge.hpp
@@ -54,7 +54,7 @@ void BaseMultiEdge<D, E>::linearizeOplus(JacobianWorkspace& jacobianWorkspace)
   for (size_t i = 0; i < _vertices.size(); ++i) {
     OptimizableGraph::Vertex* v = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
     assert(v->dimension() >= 0);
-    new (&_jacobianOplus[i]) JacobianType(jacobianWorkspace.workspaceForVertex(i), D, v->dimension());
+    new (&_jacobianOplus[i]) JacobianType(jacobianWorkspace.workspaceForVertex(i), D < 0 ? _dimension : D, v->dimension());
   }
   linearizeOplus();
 }

--- a/g2o/core/base_unary_edge.hpp
+++ b/g2o/core/base_unary_edge.hpp
@@ -83,7 +83,7 @@ void BaseUnaryEdge<D, E, VertexXiType>::constructQuadraticForm()
 template <int D, typename E, typename VertexXiType>
 void BaseUnaryEdge<D, E, VertexXiType>::linearizeOplus(JacobianWorkspace& jacobianWorkspace)
 {
-  new (&_jacobianOplusXi) JacobianXiOplusType(jacobianWorkspace.workspaceForVertex(0), D, VertexXiType::Dimension);
+  new (&_jacobianOplusXi) JacobianXiOplusType(jacobianWorkspace.workspaceForVertex(0), D < 0 ? _dimension : D, VertexXiType::Dimension);
   linearizeOplus();
 }
 


### PR DESCRIPTION
I was using an edge class derived from:
`g2o::BaseBinaryEdge<Eigen::Dynamic,  Eigen::Matrix<double, Eigen::Dynamic, 4>, vertex_type, vertex_type>`

The program always crash during optimisation. I found the problem is that when Edge dimension is Eigen::Dynamic, the jacobian is constructed with wrong parameters. This patch fixes the problem.

When D is static (>0), the changed parameter is still a compile-time constant, without overhead.