### PR TITLE
correct approximate B and R when theta<eps

### DIFF
--- a/g2o/types/sim3/sim3.h
+++ b/g2o/types/sim3/sim3.h
@@ -94,7 +94,7 @@ namespace g2o
           {
             A = 1./2.;
             B = 1./6.;
-            R = (I + Omega + Omega*Omega);
+            R = (I + Omega + Omega*Omega/2);//R=I+(1-cos(theta))*a^a^+sin(theta)*a^~=(omit O(theta^3))=I+theta^2/2*a^a^+theta*a^
           }
           else
           {
@@ -111,8 +111,9 @@ namespace g2o
           {
             double sigma2= sigma*sigma;
             A = ((sigma-1)*s+1)/sigma2;
-            B= ((0.5*sigma2-sigma+1)*s)/(sigma2*sigma);
-            R = (I + Omega + Omega2);
+            B= ((0.5*sigma2-sigma+1)*s-1)/(sigma2*sigma);//B=[C-((s*cos(theta)-1)*sigma+s*sin(theta)*theta)/(sigma^2+theta^2)]/theta^2~=(omit O(theta^2))=
+	    //(1/2*s*sigma-s)/(sigma^2)+[C-(s-1)*sigma/(sigma^2+theta^2)]/theta^2~=(0.5*sigma^2*s-s*sigma)/sigma^3+[s-1]/sigma^3=[s*(0.5*sigma^2-sigma+1)-1]/sigma^3  
+            R = (I + Omega + Omega2/2);//R=I+(1-cos(theta))*a^a^+sin(theta)*a^~=I+theta^2/2*a^a^+theta*a^
           }
           else
           {
@@ -185,7 +186,11 @@ namespace g2o
             omega=0.5*deltaR(R);
             Omega = skew(omega);
             A = ((sigma-1)*s+1)/(sigma2);
-            B = ((0.5*sigma2-sigma+1)*s)/(sigma2*sigma);
+            B = ((0.5*sigma2-sigma+1)*s-1)/(sigma2*sigma);//B=[C-((s*cos(theta)-1)*sigma+s*sin(theta)*theta)/(sigma^2+theta^2)]/theta^2
+	    //use limit(theta->0)(B)=limit(theta->0){[(sigma2+theta2)*(s*sigma*sin(theta)-s*sin(theta)-s*theta*cos(theta))+(s*cos(theta)*sigma-sigma+s*sin(theta)*theta)*2*theta]/(2*theta)}=
+	    //=limit(theta->0)(s*sigma-s)*sin(theta)/(2*(sigma2+theta2)*theta)+limit(theta->0)[-s*cos(theta)/(2*(sigma2+theta2))+(s*cos(theta)*sigma-sigma+s*sin(theta)*theta)/(sigma2+theta2)^2]=
+	    //=limit(theta->0)(s*sigma-s)*cos(theta)/(2*(sigma2+3*theta2))+-s/(2*sigma2)+(s-1)/sigma^3=
+	    //=(s*sigma-s)/2/sigma2-s/2/sigma2+(s-1)/sigma^3=[(0.5*sigma2-sigma+1)*s-1]/sigma^3
           }
           else
           {


### PR DESCRIPTION
For approximate B problem:
because B=[C-((s*cos(theta)-1)*sigma+s*sin(theta)*theta)/(sigma^2+theta^2)]/theta^2 when theta is small(<eps) we can use two ways to get B's approximate expression (one is Taylor expansion and omit O(theta^2) in numerator and denominator, the other is limit theory by L Hospital rule)
1st way is:
```
B~=(omit theta^2&&less)
=(1/2*s*sigma-s)/(sigma^2)+[C-(s-1)*sigma/(sigma^2+theta^2)]/theta^2
~=(0.5*sigma^2*s-s*sigma)/sigma^3+[s-1]/sigma^3
=[s*(0.5*sigma^2-sigma+1)-1]/sigma^3  
```
2nd way is:
```
limit(theta->0)(B)=limit(theta->0){[(sigma2+theta2)*(s*sigma*sin(theta)-s*sin(theta)-s*theta*cos(theta))+(s*cos(theta)*sigma-sigma+s*sin(theta)*theta)*2*theta]/(2*theta)}
=limit(theta->0)(s*sigma-s)*sin(theta)/(2*(sigma2+theta2)*theta)+limit(theta->0)[-s*cos(theta)/(2*(sigma2+theta2))+(s*cos(theta)*sigma-sigma+s*sin(theta)*theta)/(sigma2+theta2)^2]
=limit(theta->0)(s*sigma-s)*cos(theta)/(2*(sigma2+3*theta2))+-s/(2*sigma2)+(s-1)/sigma^3
=(s*sigma-s)/2/sigma2-s/2/sigma2+(s-1)/sigma^3
=[(0.5*sigma2-sigma+1)*s-1]/sigma^3
```
the old code has no -1, so I was confused and want to know if I was wrong or missed some concept?
For approximate R problem:
because 
```
R=I+(1-cos(theta))*a^a^+sin(theta)*a^
~=(by Taylor expansion and omit O(theta^3))=I+theta^2/2*a^a^+theta*a^
```
the old code has no /2, so I add this correction. 
If I was wrong or missed some concept, could you tell me the reason? Thanks.