### PR TITLE
Remove temp object creation to avoid alignment assertion in debug mode

### DIFF
--- a/g2o/types/sba/sbacam.h
+++ b/g2o/types/sba/sbacam.h
@@ -74,7 +74,6 @@ namespace g2o {
       // initialize an object
       SBACam()
       {
-        SE3Quat();
         setKcam(1,1,0.5,0.5,0);  // unit image projection
       }
 


### PR DESCRIPTION
The PR fixes alignment assertion reported for a temporary stack object in debug mode
```
/usr/include/eigen3/Eigen/src/Core/DenseStorage.h:128: Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 4; int MatrixOrArrayOptions = 0]: Assertion `(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.
```