### PR TITLE
TimeUtil Cross Platform Simplification

### DIFF
--- a/g2o/stuff/timeutil.cpp
+++ b/g2o/stuff/timeutil.cpp
@@ -27,98 +27,17 @@
 #include "timeutil.h"
 #include <iostream>
 
-#ifdef _WINDOWS
-#include <time.h>
-#include <windows.h>
-#endif
-
-#ifdef UNIX
-#include <unistd.h>
-#endif
-
 namespace g2o {
 
-#ifdef _WINDOWS
-#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
-  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
-#else
-  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
-#endif
+  ScopeTime::ScopeTime(const char* title) : _title(title), _startTime(get_monotonic_time()) {}
 
-struct timezone
-{
-  int  tz_minuteswest; /* minutes W of Greenwich */
-  int  tz_dsttime;     /* type of dst correction */
-};
+  ScopeTime::~ScopeTime() {
+    std::cerr << _title<<" took "<<1000*(get_monotonic_time()-_startTime)<<"ms.\n";
+  }
 
-int gettimeofday(struct timeval *tv, struct timezone *tz)
-{
-// Define a structure to receive the current Windows filetime
-  FILETIME ft;
- 
-// Initialize the present time to 0 and the timezone to UTC
-  unsigned __int64 tmpres = 0;
-  static int tzflag = 0;
- 
-  if (NULL != tv)
+  double get_monotonic_time()
   {
-    GetSystemTimeAsFileTime(&ft);
- 
-// The GetSystemTimeAsFileTime returns the number of 100 nanosecond 
-// intervals since Jan 1, 1601 in a structure. Copy the high bits to 
-// the 64 bit tmpres, shift it left by 32 then or in the low 32 bits.
-    tmpres |= ft.dwHighDateTime;
-    tmpres <<= 32;
-    tmpres |= ft.dwLowDateTime;
- 
-// Convert to microseconds by dividing by 10
-    tmpres /= 10;
- 
-// The Unix epoch starts on Jan 1 1970.  Need to subtract the difference 
-// in seconds from Jan 1 1601.
-    tmpres -= DELTA_EPOCH_IN_MICROSECS;
- 
-// Finally change microseconds to seconds and place in the seconds value. 
-// The modulus picks up the microseconds.
-    tv->tv_sec = (long)(tmpres / 1000000UL);
-    tv->tv_usec = (long)(tmpres % 1000000UL);
+    return seconds{ std::chrono::steady_clock::now().time_since_epoch() }.count();
   }
- 
-  if (NULL != tz) {
-    if (!tzflag) {
-      _tzset();
-      tzflag++;
-    }
-
-    long sec;
-    int hours;
-    _get_timezone(&sec);
-    _get_daylight(&hours);
-  
-// Adjust for the timezone west of Greenwich
-    tz->tz_minuteswest = sec / 60;
-    tz->tz_dsttime = hours;
-  }
- 
-  return 0;
-}
-#endif
-
-ScopeTime::ScopeTime(const char* title) : _title(title), _startTime(get_monotonic_time()) {}
-
-ScopeTime::~ScopeTime() {
-  std::cerr << _title<<" took "<<1000*(get_monotonic_time()-_startTime)<<"ms.\n";
-}
-
-double get_monotonic_time()
-{
-#if (defined(_POSIX_TIMERS) && (_POSIX_TIMERS+0 >= 0) && defined(_POSIX_MONOTONIC_CLOCK))
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return ts.tv_sec + ts.tv_nsec*1e-9;
-#else
-  return get_time();
-#endif
-}
 
 } // end namespace

--- a/g2o/stuff/timeutil.h
+++ b/g2o/stuff/timeutil.h
@@ -27,13 +27,8 @@
 #ifndef G2O_TIMEUTIL_H
 #define G2O_TIMEUTIL_H
 
-#ifdef _WINDOWS
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
-
 #include <string>
+#include <chrono>
 
 #include "g2o_stuff_api.h"
 
@@ -78,22 +73,14 @@ if (1) {\
 
 namespace g2o {
 
-#ifdef _WINDOWS
-typedef struct timeval {
-  long tv_sec;
-  long tv_usec;
-} timeval;
-G2O_STUFF_API int gettimeofday(struct timeval *tv, struct timezone *tz);
-#endif
+using seconds = std::chrono::duration<double>;
 
 /**
  * return the current time in seconds since 1. Jan 1970
  */
 inline double get_time() 
 {
-  struct timeval ts;
-  gettimeofday(&ts,0);
-  return ts.tv_sec + ts.tv_usec*1e-6;
+  return seconds{std::chrono::system_clock::now().time_since_epoch()}.count();
 }
 
 /**


### PR DESCRIPTION
- simplify timeutil to not require platform specific headers