### PR TITLE
Improvements in read methods of ParameterSE3Offset and EdgeSE3Prior

### DIFF
--- a/g2o/types/slam3d/edge_se3_prior.cpp
+++ b/g2o/types/slam3d/edge_se3_prior.cpp
@@ -63,16 +63,15 @@ namespace g2o {
     setMeasurement(internal::fromVectorQT(meas));
     // don't need this if we don't use it in error calculation (???)
     // information matrix is the identity for features, could be changed to allow arbitrary covariances    
-    if (is.bad()) {
-      return false;
+    if (is.good()) {
+      for ( int i=0; i<information().rows(); i++)
+        for (int j=i; j<information().cols(); j++){
+          is >> information()(i,j);
+          if (i!=j)
+            information()(j,i)=information()(i,j);
+        }
     }
-    for ( int i=0; i<information().rows() && is.good(); i++)
-      for (int j=i; j<information().cols() && is.good(); j++){
-        is >> information()(i,j);
-        if (i!=j)
-          information()(j,i)=information()(i,j);
-      }
-    return true;
+    return !is.fail();
   }
 
   bool EdgeSE3Prior::write(std::ostream& os) const {

--- a/g2o/types/slam3d/edge_se3_prior.cpp
+++ b/g2o/types/slam3d/edge_se3_prior.cpp
@@ -72,10 +72,6 @@ namespace g2o {
         if (i!=j)
           information()(j,i)=information()(i,j);
       }
-    if (is.bad()) {
-      //  we overwrite the information matrix
-      information().setIdentity();
-    } 
     return true;
   }
 

--- a/g2o/types/slam3d/parameter_se3_offset.cpp
+++ b/g2o/types/slam3d/parameter_se3_offset.cpp
@@ -52,7 +52,7 @@ namespace g2o {
     // normalize the quaternion to recover numerical precision lost by storing as human readable text
     Vector4D::MapType(off.data()+3).normalize();
     setOffset(internal::fromVectorQT(off));
-    return true;
+    return !is.fail();
   }
   
   bool ParameterSE3Offset::write(std::ostream& os) const {

--- a/g2o/types/slam3d/parameter_se3_offset.cpp
+++ b/g2o/types/slam3d/parameter_se3_offset.cpp
@@ -52,7 +52,7 @@ namespace g2o {
     // normalize the quaternion to recover numerical precision lost by storing as human readable text
     Vector4D::MapType(off.data()+3).normalize();
     setOffset(internal::fromVectorQT(off));
-    return is.good();
+    return true;
   }
   
   bool ParameterSE3Offset::write(std::ostream& os) const {


### PR DESCRIPTION
Fixed return value of ParameterSE3Offset.read: returned false even though line was fully read if there as no superfluous whitespace at the end of the line (fixes #162).

Removed undesirable fallback to identity matrix in read method of EDGE_SE3_PRIOR because such silent fallbacks can lead to unexpected results.
