### PR TITLE
right mouse button translates graph in viewer window

### DIFF
--- a/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
+++ b/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
@@ -143,10 +143,10 @@ void G2oQGLViewer::init()
 
   // mouse bindings
 #ifdef QGLVIEWER_DEPRECATED_MOUSEBINDING
-  setMouseBinding(Qt::NoModifier, Qt::RightButton, CAMERA, ZOOM);
+  setMouseBinding(Qt::NoModifier, Qt::RightButton, CAMERA, TRANSLATE);
   setMouseBinding(Qt::NoModifier, Qt::MidButton, CAMERA, TRANSLATE);
 #else
-  setMouseBinding(Qt::RightButton, CAMERA, ZOOM);
+  setMouseBinding(Qt::RightButton, CAMERA, TRANSLATE);
   setMouseBinding(Qt::MidButton, CAMERA, TRANSLATE);
 #endif
 


### PR DESCRIPTION
current g2o_viewer version does not support the functionality of dragging graph in g2o_viewer in touchpad however it is possible with middle mouse button so I put pull request to change right mouse button to drag graph instead of zoom in/out feature which is still available on touchpad scroll.

Hope this feature will lets access g2o viewer on touchpad users. Thanks