### PR TITLE
Turned "return 0" into more appropriate types

### DIFF
--- a/g2o/core/base_binary_edge.hpp
+++ b/g2o/core/base_binary_edge.hpp
@@ -60,7 +60,7 @@ OptimizableGraph::Vertex* BaseBinaryEdge<D, E, VertexXiType, VertexXjType>::crea
   switch(i) {
   case 0: return new VertexXiType();
   case 1: return new VertexXjType();
-  default: return 0;
+  default: return nullptr;
   }
 }
 

--- a/g2o/core/base_unary_edge.hpp
+++ b/g2o/core/base_unary_edge.hpp
@@ -41,7 +41,7 @@ template <int D, typename E, typename VertexXiType>
 OptimizableGraph::Vertex* BaseUnaryEdge<D, E, VertexXiType>::createVertex(int i)
 {
   if (i!=0)
-    return 0;
+    return nullptr;
   return new VertexXiType();
 }
 

--- a/g2o/core/block_solver.hpp
+++ b/g2o/core/block_solver.hpp
@@ -517,7 +517,7 @@ bool BlockSolver<Traits>::buildSystem()
     v->copyB(_b+iBase);
   }
 
-  return 0;
+  return false;
 }
 
 

--- a/g2o/core/cache.cpp
+++ b/g2o/core/cache.cpp
@@ -61,13 +61,13 @@ namespace g2o {
   OptimizableGraph::Vertex* Cache::vertex() { 
     if (container() ) 
       return container()->vertex(); 
-    return 0; 
+    return nullptr; 
   }
 
   OptimizableGraph* Cache::graph() {
     if (container())
       return container()->graph();
-    return 0;
+    return nullptr;
   }
 
   CacheContainer* Cache::container() {
@@ -98,12 +98,12 @@ namespace g2o {
     ParameterVector pv(parameterIndices.size());
     for (size_t i=0; i<parameterIndices.size(); i++){
       if (parameterIndices[i]<0 || parameterIndices[i] >=(int)_parameters.size())
-  return 0;
+  return nullptr;
       pv[i]=_parameters[ parameterIndices[i] ];
     }
     CacheKey k(type_, pv);
     if (!container())
-      return 0;
+      return nullptr;
     Cache* c=container()->findCache(k);
     if (!c) {
       c = container()->createCache(k);
@@ -124,7 +124,7 @@ namespace g2o {
   Cache* CacheContainer::findCache(const Cache::CacheKey& key) {
     iterator it=find(key);
     if (it==end())
-      return 0;
+      return nullptr;
     return it->second;
   }
   
@@ -134,13 +134,13 @@ namespace g2o {
     if (!e) {
       cerr << __PRETTY_FUNCTION__ << endl;
       cerr << "fatal error in creating cache of type " << key.type() << endl;
-      return 0;
+      return nullptr;
     }
     Cache* c = dynamic_cast<Cache*>(e);
     if (! c){
       cerr << __PRETTY_FUNCTION__ << endl;
       cerr << "fatal error in creating cache of type " << key.type() << endl;
-      return 0;
+      return nullptr;
     }
     c->_container = this;
     c->_parameters = key._parameters;
@@ -149,7 +149,7 @@ namespace g2o {
       c->update();
       return c;
     } 
-    return 0;
+    return nullptr;
   }
   
   OptimizableGraph::Vertex* CacheContainer::vertex() {
@@ -159,7 +159,7 @@ namespace g2o {
   OptimizableGraph* CacheContainer::graph(){
     if (_vertex)
       return _vertex->graph();
-    return 0;
+    return nullptr;
   }
 
   void CacheContainer::update() {

--- a/g2o/core/factory.cpp
+++ b/g2o/core/factory.cpp
@@ -151,7 +151,7 @@ HyperGraph::HyperGraphElement* Factory::construct(const std::string& tag) const
     //cerr << "tag " << tag << " -> " << (void*) foundIt->second->creator << " " << foundIt->second->creator->name() << endl;
     return foundIt->second->creator->construct();
   }
-  return 0;
+  return nullptr;
 }
 
 const std::string& Factory::tag(const HyperGraph::HyperGraphElement* e) const
@@ -210,7 +210,7 @@ HyperGraph::HyperGraphElement* Factory::construct(const std::string& tag, const 
   if (foundIt != _creator.end() && foundIt->second->elementTypeBit >= 0 && elemsToConstruct.test(foundIt->second->elementTypeBit)) {
     return foundIt->second->creator->construct();
   }
-  return 0;
+  return nullptr;
 }
 
 } // end namespace

--- a/g2o/core/hyper_graph.h
+++ b/g2o/core/hyper_graph.h
@@ -87,7 +87,7 @@ namespace g2o {
          * returns the type of the graph element, see HyperGraphElementType
          */
         virtual HyperGraphElementType elementType() const = 0;
-	HyperGraphElement* clone() const { return 0; }
+	HyperGraphElement* clone() const { return nullptr; }
       };
 
       /**

--- a/g2o/core/hyper_graph_action.cpp
+++ b/g2o/core/hyper_graph_action.cpp
@@ -53,7 +53,7 @@ namespace g2o {
 
   HyperGraphAction* HyperGraphAction::operator()(const HyperGraph*, Parameters*)
   {
-    return 0;
+    return nullptr;
   }
 
   HyperGraphElementAction::Parameters::~Parameters()
@@ -73,12 +73,12 @@ namespace g2o {
 
   HyperGraphElementAction* HyperGraphElementAction::operator()(HyperGraph::HyperGraphElement* , HyperGraphElementAction::Parameters* )
   {
-    return 0;
+    return nullptr;
   }
   
   HyperGraphElementAction* HyperGraphElementAction::operator()(const HyperGraph::HyperGraphElement* , HyperGraphElementAction::Parameters* )
   {
-    return 0;
+    return nullptr;
   }
   
   HyperGraphElementAction::~HyperGraphElementAction()
@@ -102,7 +102,7 @@ namespace g2o {
     ActionMap::iterator it=_actionMap.find(typeid(*element).name());
     //cerr << typeid(*element).name() << endl;
     if (it==_actionMap.end())
-      return 0;
+      return nullptr;
     HyperGraphElementAction* action=it->second;
     return (*action)(element, params);
   }
@@ -111,7 +111,7 @@ namespace g2o {
   {
     ActionMap::iterator it=_actionMap.find(typeid(*element).name());
     if (it==_actionMap.end())
-      return 0;
+      return nullptr;
     HyperGraphElementAction* action=it->second;
     return (*action)(element, params);
   }
@@ -170,7 +170,7 @@ namespace g2o {
     HyperGraphElementAction::ActionMap::iterator it=_actionMap.find(name);
     if (it!=_actionMap.end())
       return it->second;
-    return 0;
+    return nullptr;
   }
 
   bool HyperGraphActionLibrary::registerAction(HyperGraphElementAction* action)
@@ -181,7 +181,7 @@ namespace g2o {
       collection = dynamic_cast<HyperGraphElementActionCollection*>(oldAction);
       if (! collection) {
         cerr << __PRETTY_FUNCTION__ << ": fatal error, a collection is not at the first level in the library" << endl;
-        return 0;
+        return false;
       }
     }
     if (! collection) {

--- a/g2o/core/optimizable_graph.cpp
+++ b/g2o/core/optimizable_graph.cpp
@@ -80,7 +80,7 @@ namespace g2o {
 
   OptimizableGraph::Vertex* OptimizableGraph::Vertex::clone() const
   {
-    return 0;
+    return nullptr;
   }
 
   bool OptimizableGraph::Vertex::setEstimateData(const number_t* v)
@@ -131,19 +131,19 @@ namespace g2o {
 
   OptimizableGraph* OptimizableGraph::Edge::graph(){
     if (! _vertices.size())
-      return 0;
+      return nullptr;
     OptimizableGraph::Vertex* v=(OptimizableGraph::Vertex*)_vertices[0];
     if (!v)
-      return 0;
+      return nullptr;
     return v->graph();
   }
 
   const OptimizableGraph* OptimizableGraph::Edge::graph() const{
     if (! _vertices.size())
-      return 0;
+      return nullptr;
     const OptimizableGraph::Vertex* v=(const OptimizableGraph::Vertex*) _vertices[0];
     if (!v)
-      return 0;
+      return nullptr;
     return v->graph();
   }
 
@@ -214,7 +214,7 @@ namespace g2o {
   OptimizableGraph::Edge* OptimizableGraph::Edge::clone() const
   {
     // TODO
-    return 0;
+    return nullptr;
   }
 
 

--- a/g2o/core/optimizable_graph.h
+++ b/g2o/core/optimizable_graph.h
@@ -439,9 +439,9 @@ namespace g2o {
         //! returns the dimensions of the error function
         int dimension() const { return _dimension;}
 
-        G2O_ATTRIBUTE_DEPRECATED(virtual Vertex* createFrom()) {return 0;}
-	G2O_ATTRIBUTE_DEPRECATED(virtual Vertex* createTo())   {return 0;}
-	virtual Vertex* createVertex(int) {return 0;}
+        G2O_ATTRIBUTE_DEPRECATED(virtual Vertex* createFrom()) {return nullptr;}
+	G2O_ATTRIBUTE_DEPRECATED(virtual Vertex* createTo())   {return nullptr;}
+	virtual Vertex* createVertex(int) {return nullptr;}
 
         //! read the vertex from a stream, i.e., the internal state of the vertex
         virtual bool read(std::istream& is) = 0;

--- a/g2o/core/optimization_algorithm_factory.cpp
+++ b/g2o/core/optimization_algorithm_factory.cpp
@@ -89,13 +89,13 @@ namespace g2o {
       return (*foundIt)->construct();
     }
     cerr << "SOLVER FACTORY WARNING: Unable to create solver " << name << endl;
-    return 0;
+    return nullptr;
   }
 
   void OptimizationAlgorithmFactory::destroy()
   {
     delete factoryInstance;
-    factoryInstance = 0;
+    factoryInstance = nullptr;
   }
 
   void OptimizationAlgorithmFactory::listSolvers(std::ostream& os) const

--- a/g2o/core/parameter_container.cpp
+++ b/g2o/core/parameter_container.cpp
@@ -70,21 +70,21 @@ namespace g2o {
   Parameter* ParameterContainer::getParameter(int id) {
     iterator it=find(id);
     if (it==end())
-      return 0;
+      return nullptr;
     return it->second;
   }
 
   const Parameter* ParameterContainer::getParameter(int id) const {
     const_iterator it=find(id);
     if (it==end())
-      return 0;
+      return nullptr;
     return it->second;
   }
 
   Parameter* ParameterContainer::detachParameter(int id){
     iterator it=find(id);
     if (it==end())
-      return 0;
+      return nullptr;
     Parameter* p=it->second;
     erase(it);
     return p;

--- a/g2o/core/robust_kernel_factory.cpp
+++ b/g2o/core/robust_kernel_factory.cpp
@@ -83,7 +83,7 @@ RobustKernel* RobustKernelFactory::construct(const std::string& tag) const
   if (foundIt != _creator.end()) {
     return foundIt->second->construct();
   }
-  return 0;
+  return nullptr;
 }
 
 AbstractRobustKernelCreator* RobustKernelFactory::creator(const std::string& tag) const
@@ -92,7 +92,7 @@ AbstractRobustKernelCreator* RobustKernelFactory::creator(const std::string& tag
   if (foundIt != _creator.end()) {
     return foundIt->second;
   }
-  return 0;
+  return nullptr;
 }
 
 void RobustKernelFactory::fillKnownKernels(std::vector<std::string>& types) const

--- a/g2o/core/sparse_block_matrix.hpp
+++ b/g2o/core/sparse_block_matrix.hpp
@@ -93,7 +93,7 @@ namespace g2o {
     typename SparseBlockMatrix<MatrixType>::SparseMatrixBlock* _block=0;
     if (it==_blockCols[c].end()){
       if (!_hasStorage && ! alloc )
-        return 0;
+        return nullptr;
       else {
         int rb=rowsOfBlock(r);
         int cb=colsOfBlock(c);
@@ -113,7 +113,7 @@ namespace g2o {
   const typename SparseBlockMatrix<MatrixType>::SparseMatrixBlock* SparseBlockMatrix<MatrixType>::block(int r, int c) const {
     typename SparseBlockMatrix<MatrixType>::IntBlockMap::const_iterator it =_blockCols[c].find(r);
     if (it==_blockCols[c].end())
-  return 0;
+  return nullptr;
     return it->second;
   }
 

--- a/g2o/core/sparse_optimizer.cpp
+++ b/g2o/core/sparse_optimizer.cpp
@@ -117,7 +117,7 @@ namespace g2o{
 
   OptimizableGraph::Vertex* SparseOptimizer::findGauge(){
     if (vertices().empty())
-      return 0;
+      return nullptr;
 
     int maxDim=0;
     for (HyperGraph::VertexIDMap::iterator it=vertices().begin(); it!=vertices().end(); ++it){

--- a/g2o/solvers/structure_only/structure_only.cpp
+++ b/g2o/solvers/structure_only/structure_only.cpp
@@ -46,7 +46,7 @@ namespace g2o {
       return optimizationAlgo;
     }
     else
-      return 0;
+      return nullptr;
   }
 
   class StructureOnlyCreator : public AbstractOptimizationAlgorithmCreator

--- a/g2o/stuff/property.h
+++ b/g2o/stuff/property.h
@@ -100,7 +100,7 @@ namespace g2o {
       {
         PropertyMapIterator it=find(name_);
         if (it==end())
-          return 0;
+          return nullptr;
         return dynamic_cast<P*>(it->second);
       }
       template <typename P> 
@@ -108,7 +108,7 @@ namespace g2o {
       {
         PropertyMapConstIterator it=find(name_);
         if (it==end())
-          return 0;
+          return nullptr;
         return dynamic_cast<P*>(it->second);
       }
 

--- a/g2o/types/data/data_queue.cpp
+++ b/g2o/types/data/data_queue.cpp
@@ -57,7 +57,7 @@ namespace g2o {
   RobotData* DataQueue::before(number_t timestamp) const
   {
     if (_buffer.size() == 0 || _buffer.begin()->first > timestamp)
-      return 0;
+      return nullptr;
     Buffer::const_iterator lb = _buffer.upper_bound(timestamp);
     --lb; // now it's the lower bound
     return lb->second;
@@ -66,10 +66,10 @@ namespace g2o {
   RobotData* DataQueue::after(number_t timestamp) const
   {
     if (_buffer.size() == 0 || _buffer.rbegin()->first < timestamp)
-      return 0;
+      return nullptr;
     Buffer::const_iterator ub = _buffer.upper_bound(timestamp);
     if (ub == _buffer.end())
-      return 0;
+      return nullptr;
     return ub->second;
   }
 

--- a/g2o/types/data/robot_laser.cpp
+++ b/g2o/types/data/robot_laser.cpp
@@ -140,7 +140,7 @@ namespace g2o {
   HyperGraphElementAction* RobotLaserDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams){

--- a/g2o/types/data/vertex_ellipse.cpp
+++ b/g2o/types/data/vertex_ellipse.cpp
@@ -122,7 +122,7 @@ namespace g2o {
   HyperGraphElementAction* VertexEllipseDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 							       HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams){

--- a/g2o/types/data/vertex_tag.cpp
+++ b/g2o/types/data/vertex_tag.cpp
@@ -87,7 +87,7 @@ namespace g2o {
   HyperGraphElementAction* VertexTagDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams){

--- a/g2o/types/deprecated/slam3d/edge_se3_pointxyz_disparity.cpp
+++ b/g2o/types/deprecated/slam3d/edge_se3_pointxyz_disparity.cpp
@@ -219,9 +219,9 @@ namespace deprecated {
 
   HyperGraphElementAction* EdgeProjectDisparityDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                 HyperGraphElementAction::Parameters* /* params_ */){
-    return 0;
+    return nullptr;
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     EdgeSE3PointXYZDisparity* e =  static_cast<EdgeSE3PointXYZDisparity*>(element);
     VertexSE3* fromEdge = static_cast<VertexSE3*>(e->vertex(0));
     VertexPointXYZ* toEdge   = static_cast<VertexPointXYZ*>(e->vertex(1));

--- a/g2o/types/deprecated/slam3d/edge_se3_quat.cpp
+++ b/g2o/types/deprecated/slam3d/edge_se3_quat.cpp
@@ -119,11 +119,11 @@ namespace deprecated {
 
   HyperGraphElementAction* EdgeSE3WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     EdgeSE3* e =  static_cast<EdgeSE3*>(element);
@@ -151,7 +151,7 @@ namespace deprecated {
   HyperGraphElementAction* EdgeSE3DrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     refreshPropertyPtrs(params_);
     if (! _previousParams)
       return this;

--- a/g2o/types/deprecated/slam3d/parameter_camera.cpp
+++ b/g2o/types/deprecated/slam3d/parameter_camera.cpp
@@ -134,7 +134,7 @@ namespace deprecated {
   HyperGraphElementAction* CacheCameraDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     CacheCamera* that = static_cast<CacheCamera*>(element);
     refreshPropertyPtrs(params);
     if (! _previousParams)

--- a/g2o/types/deprecated/slam3d/parameter_se3_offset.cpp
+++ b/g2o/types/deprecated/slam3d/parameter_se3_offset.cpp
@@ -116,7 +116,7 @@ namespace deprecated {
   HyperGraphElementAction* CacheSE3OffsetDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                 HyperGraphElementAction::Parameters* params){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     CacheSE3Offset* that = static_cast<CacheSE3Offset*>(element);
     refreshPropertyPtrs(params);
     if (! _previousParams)

--- a/g2o/types/deprecated/slam3d/vertex_pointxyz.cpp
+++ b/g2o/types/deprecated/slam3d/vertex_pointxyz.cpp
@@ -73,7 +73,7 @@ namespace deprecated {
                      HyperGraphElementAction::Parameters* params ){
 
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params);
     if (! _previousParams)
@@ -106,11 +106,11 @@ namespace deprecated {
   HyperGraphElementAction* VertexPointXYZWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_ )
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, no valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     VertexPointXYZ* v = static_cast<VertexPointXYZ*>(element);

--- a/g2o/types/deprecated/slam3d/vertex_se3_quat.cpp
+++ b/g2o/types/deprecated/slam3d/vertex_se3_quat.cpp
@@ -67,11 +67,11 @@ namespace deprecated {
 
   HyperGraphElementAction* VertexSE3WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, no valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
     
     VertexSE3* v =  static_cast<VertexSE3*>(element);
@@ -121,7 +121,7 @@ namespace deprecated {
   HyperGraphElementAction* VertexSE3DrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     if (! _cacheDrawActions){
       _cacheDrawActions = HyperGraphActionLibrary::instance()->actionByName("draw");
     }

--- a/g2o/types/sclam2d/edge_se2_odom_differential_calib.cpp
+++ b/g2o/types/sclam2d/edge_se2_odom_differential_calib.cpp
@@ -71,7 +71,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE2OdomDifferentialCalibDrawAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* )
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     EdgeSE2OdomDifferentialCalib* e = static_cast<EdgeSE2OdomDifferentialCalib*>(element);
     VertexSE2* fromEdge = static_cast<VertexSE2*>(e->vertex(0));
     VertexSE2* toEdge   = static_cast<VertexSE2*>(e->vertex(1));

--- a/g2o/types/sclam2d/edge_se2_sensor_calib.cpp
+++ b/g2o/types/sclam2d/edge_se2_sensor_calib.cpp
@@ -85,7 +85,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE2SensorCalibDrawAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* )
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     EdgeSE2SensorCalib* e = static_cast<EdgeSE2SensorCalib*>(element);
     VertexSE2* fromEdge = static_cast<VertexSE2*>(e->vertex(0));
     VertexSE2* toEdge   = static_cast<VertexSE2*>(e->vertex(1));

--- a/g2o/types/slam2d/edge_pointxy.h
+++ b/g2o/types/slam2d/edge_pointxy.h
@@ -74,7 +74,7 @@ namespace g2o {
       }
 
 
-      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0.;}
+      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0;}
 #ifndef NUMERIC_JACOBIAN_TWO_D_TYPES
       virtual void linearizeOplus();
 #endif

--- a/g2o/types/slam2d/edge_se2.cpp
+++ b/g2o/types/slam2d/edge_se2.cpp
@@ -104,11 +104,11 @@ namespace g2o {
 
   HyperGraphElementAction* EdgeSE2WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     EdgeSE2* e =  static_cast<EdgeSE2*>(element);
@@ -141,7 +141,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE2DrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam2d/edge_se2_pointxy.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy.cpp
@@ -97,11 +97,11 @@ namespace g2o {
 
   HyperGraphElementAction* EdgeSE2PointXYWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     EdgeSE2PointXY* e =  static_cast<EdgeSE2PointXY*>(element);
@@ -122,7 +122,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE2PointXYDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                 HyperGraphElementAction::Parameters*  params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
@@ -71,11 +71,11 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE2PointXYBearingWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element,
                          HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     EdgeSE2PointXYBearing* e =  static_cast<EdgeSE2PointXYBearing*>(element);
@@ -93,7 +93,7 @@ namespace g2o {
 
   HyperGraphElementAction* EdgeSE2PointXYBearingDrawAction::operator()(HyperGraph::HyperGraphElement* element,  HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam2d/edge_xy_prior.h
+++ b/g2o/types/slam2d/edge_xy_prior.h
@@ -72,7 +72,7 @@ namespace g2o {
       }
 
 
-      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0;}
+      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0.;}
 #ifndef NUMERIC_JACOBIAN_TWO_D_TYPES
       virtual void linearizeOplus();
 #endif

--- a/g2o/types/slam2d/vertex_point_xy.cpp
+++ b/g2o/types/slam2d/vertex_point_xy.cpp
@@ -59,12 +59,12 @@ namespace g2o {
 
   HyperGraphElementAction* VertexPointXYWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
          
     VertexPointXY* v =  static_cast<VertexPointXY*>(element);
@@ -90,7 +90,7 @@ namespace g2o {
                      HyperGraphElementAction::Parameters* params ){
 
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     initializeDrawActionsCache();
     refreshPropertyPtrs(params);
     if (! _previousParams)

--- a/g2o/types/slam2d/vertex_se2.cpp
+++ b/g2o/types/slam2d/vertex_se2.cpp
@@ -58,11 +58,11 @@ namespace g2o {
 
   HyperGraphElementAction* VertexSE2WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params || !params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, no valid output stream specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     VertexSE2* v =  static_cast<VertexSE2*>(element);
@@ -93,7 +93,7 @@ namespace g2o {
   HyperGraphElementAction* VertexSE2DrawAction::operator()(HyperGraph::HyperGraphElement* element,
                  HyperGraphElementAction::Parameters* params_){
    if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     initializeDrawActionsCache();
     refreshPropertyPtrs(params_);
 

--- a/g2o/types/slam2d_addons/edge_line2d.h
+++ b/g2o/types/slam2d_addons/edge_line2d.h
@@ -79,7 +79,7 @@ namespace g2o {
       }
 
 
-      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0.;}
+      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0;}
 #ifndef NUMERIC_JACOBIAN_THREE_D_TYPES
       virtual void linearizeOplus();
 #endif

--- a/g2o/types/slam2d_addons/edge_line2d_pointxy.cpp
+++ b/g2o/types/slam2d_addons/edge_line2d_pointxy.cpp
@@ -109,11 +109,11 @@ namespace g2o {
 
 //   HyperGraphElementAction* EdgeLine2DPointXYWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 //     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
 //     if (!params->os){
 //       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-//       return 0;
+//       return nullptr;
 //     }
 
 //     EdgeLine2DPointXY* e =  static_cast<EdgeLine2DPointXY*>(element);
@@ -132,7 +132,7 @@ namespace g2o {
 //   HyperGraphElementAction* EdgeLine2DPointXYDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 //                 HyperGraphElementAction::Parameters*  params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 
 //     refreshPropertyPtrs(params_);
 //     if (! _previousParams)

--- a/g2o/types/slam2d_addons/edge_se2_line2d.cpp
+++ b/g2o/types/slam2d_addons/edge_se2_line2d.cpp
@@ -110,11 +110,11 @@ namespace g2o {
 
 //   HyperGraphElementAction* EdgeSE2Line2DWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 //     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
 //     if (!params->os){
 //       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-//       return 0;
+//       return nullptr;
 //     }
 
 //     EdgeSE2Line2D* e =  static_cast<EdgeSE2Line2D*>(element);
@@ -133,7 +133,7 @@ namespace g2o {
 //   HyperGraphElementAction* EdgeSE2Line2DDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 //                 HyperGraphElementAction::Parameters*  params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 
 //     refreshPropertyPtrs(params_);
 //     if (! _previousParams)

--- a/g2o/types/slam2d_addons/edge_se2_segment2d.cpp
+++ b/g2o/types/slam2d_addons/edge_se2_segment2d.cpp
@@ -113,11 +113,11 @@ namespace g2o {
 
 //   HyperGraphElementAction* EdgeSE2Segment2DWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 //     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
 //     if (!params->os){
 //       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-//       return 0;
+//       return nullptr;
 //     }
 
 //     EdgeSE2Segment2D* e =  static_cast<EdgeSE2Segment2D*>(element);
@@ -136,7 +136,7 @@ namespace g2o {
 //   HyperGraphElementAction* EdgeSE2Segment2DDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 //                 HyperGraphElementAction::Parameters*  params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 
 //     refreshPropertyPtrs(params_);
 //     if (! _previousParams)

--- a/g2o/types/slam2d_addons/vertex_line2d.cpp
+++ b/g2o/types/slam2d_addons/vertex_line2d.cpp
@@ -63,7 +63,7 @@ namespace g2o {
 
 //   HyperGraphElementAction* VertexLine2DWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
 //     if (typeid(*element).name()!=_typeName)
-//       return 0;
+//       return nullptr;
 
 //     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
 //     if (!params->os){
@@ -94,7 +94,7 @@ namespace g2o {
                      HyperGraphElementAction::Parameters* params_ ){
 
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam2d_addons/vertex_segment2d.cpp
+++ b/g2o/types/slam2d_addons/vertex_segment2d.cpp
@@ -64,12 +64,12 @@ namespace g2o {
 
   HyperGraphElementAction* VertexSegment2DWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     VertexSegment2D* v =  static_cast<VertexSegment2D*>(element);
@@ -97,7 +97,7 @@ namespace g2o {
                      HyperGraphElementAction::Parameters* params_ ){
 
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam3d/edge_pointxyz.h
+++ b/g2o/types/slam3d/edge_pointxyz.h
@@ -74,7 +74,7 @@ namespace g2o {
       }
 
 
-      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0.;}
+      virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0;}
 #ifndef NUMERIC_JACOBIAN_THREE_D_TYPES
       virtual void linearizeOplus();
 #endif

--- a/g2o/types/slam3d/edge_se3.cpp
+++ b/g2o/types/slam3d/edge_se3.cpp
@@ -118,11 +118,11 @@ namespace g2o {
 
   HyperGraphElementAction* EdgeSE3WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, on valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     EdgeSE3* e =  static_cast<EdgeSE3*>(element);
@@ -147,7 +147,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE3DrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     refreshPropertyPtrs(params_);
     if (! _previousParams)
       return this;

--- a/g2o/types/slam3d/edge_se3_pointxyz.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz.cpp
@@ -157,9 +157,8 @@ namespace g2o {
   }
 
 
-  void EdgeSE3PointXYZ::initialEstimate(const OptimizableGraph::VertexSet& from, OptimizableGraph::Vertex* /*to_*/)
+  void EdgeSE3PointXYZ::initialEstimate(const OptimizableGraph::VertexSet& /*from*/, OptimizableGraph::Vertex* /*to_*/)
   {
-    (void) from;
     assert(from.size() == 1 && from.count(_vertices[0]) == 1 && "Can not initialize VertexDepthCam position by VertexTrackXYZ");
 
     VertexSE3 *cam = dynamic_cast<VertexSE3*>(_vertices[0]);
@@ -179,7 +178,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE3PointXYZDrawAction::operator()(HyperGraph::HyperGraphElement* element,
                HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     refreshPropertyPtrs(params_);
     if (! _previousParams)
       return this;

--- a/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
@@ -221,7 +221,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeProjectDisparityDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                 HyperGraphElementAction::Parameters*  params_ ){
   if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     refreshPropertyPtrs(params_);
     if (! _previousParams)
       return this;

--- a/g2o/types/slam3d/edge_xyz_prior.h
+++ b/g2o/types/slam3d/edge_xyz_prior.h
@@ -72,7 +72,7 @@ namespace g2o {
 
     virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& /*from*/, 
              OptimizableGraph::Vertex* /*to*/) { 
-      return 0.;
+      return 0;
     }
   };
 

--- a/g2o/types/slam3d/parameter_camera.cpp
+++ b/g2o/types/slam3d/parameter_camera.cpp
@@ -121,7 +121,7 @@ namespace g2o {
   HyperGraphElementAction* CacheCameraDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     CacheCamera* that = static_cast<CacheCamera*>(element);
     refreshPropertyPtrs(params);
     if (! _previousParams)

--- a/g2o/types/slam3d/parameter_se3_offset.cpp
+++ b/g2o/types/slam3d/parameter_se3_offset.cpp
@@ -106,7 +106,7 @@ namespace g2o {
   HyperGraphElementAction* CacheSE3OffsetDrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                 HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     CacheSE3Offset* that = static_cast<CacheSE3Offset*>(element);
     refreshPropertyPtrs(params_);
     if (! _previousParams)

--- a/g2o/types/slam3d/vertex_pointxyz.cpp
+++ b/g2o/types/slam3d/vertex_pointxyz.cpp
@@ -73,7 +73,7 @@ namespace g2o {
                      HyperGraphElementAction::Parameters* params ){
 
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     initializeDrawActionsCache();
     refreshPropertyPtrs(params);
     if (! _previousParams)
@@ -107,11 +107,11 @@ namespace g2o {
   HyperGraphElementAction* VertexPointXYZWriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_ )
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, no valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
 
     VertexPointXYZ* v = static_cast<VertexPointXYZ*>(element);

--- a/g2o/types/slam3d/vertex_se3.cpp
+++ b/g2o/types/slam3d/vertex_se3.cpp
@@ -67,11 +67,11 @@ namespace g2o {
 
   HyperGraphElementAction* VertexSE3WriteGnuplotAction::operator()(HyperGraph::HyperGraphElement* element, HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     WriteGnuplotAction::Parameters* params=static_cast<WriteGnuplotAction::Parameters*>(params_);
     if (!params->os){
       std::cerr << __PRETTY_FUNCTION__ << ": warning, no valid os specified" << std::endl;
-      return 0;
+      return nullptr;
     }
     
     VertexSE3* v =  static_cast<VertexSE3*>(element);
@@ -119,7 +119,7 @@ namespace g2o {
   HyperGraphElementAction* VertexSE3DrawAction::operator()(HyperGraph::HyperGraphElement* element, 
                  HyperGraphElementAction::Parameters* params_){
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
     initializeDrawActionsCache();
     refreshPropertyPtrs(params_);
 

--- a/g2o/types/slam3d_addons/edge_plane.h
+++ b/g2o/types/slam3d_addons/edge_plane.h
@@ -78,7 +78,7 @@ public:
     }
 
 
-    virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0.;}
+    virtual number_t initialEstimatePossible(const OptimizableGraph::VertexSet& , OptimizableGraph::Vertex* ) { return 0;}
 #if 0
 #ifndef NUMERIC_JACOBIAN_THREE_D_TYPES
     virtual void linearizeOplus();

--- a/g2o/types/slam3d_addons/edge_se3_line.cpp
+++ b/g2o/types/slam3d_addons/edge_se3_line.cpp
@@ -106,7 +106,7 @@ namespace g2o {
   HyperGraphElementAction* EdgeSE3Line3DDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 							       HyperGraphElementAction::Parameters* params_) {
     if(typeid(*element).name() != _typeName) {
-      return 0;
+      return nullptr;
     }
 
     refreshPropertyPtrs(params_);
@@ -128,7 +128,7 @@ namespace g2o {
     const VertexLine3D* landmark = dynamic_cast<const VertexLine3D*>(that->vertex(1));
 
     if(!robot || !landmark) {
-      return 0;
+      return nullptr;
     }
 
     Line3D line = that->measurement();

--- a/g2o/types/slam3d_addons/edge_se3_plane_calib.cpp
+++ b/g2o/types/slam3d_addons/edge_se3_plane_calib.cpp
@@ -90,7 +90,7 @@ namespace g2o
                  HyperGraphElementAction::Parameters* params_)
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)
@@ -108,7 +108,7 @@ namespace g2o
     const VertexSE3* sensor = dynamic_cast<const VertexSE3*>(that->vertex(2));
 
     if (! robot|| ! sensor)
-      return 0;
+      return nullptr;
 
     number_t d=that->measurement().distance();
     number_t azimuth=Plane3D::azimuth(that->measurement().normal());

--- a/g2o/types/slam3d_addons/vertex_line3d.cpp
+++ b/g2o/types/slam3d_addons/vertex_line3d.cpp
@@ -72,7 +72,7 @@ namespace g2o {
   HyperGraphElementAction* VertexLine3DDrawAction::operator()(HyperGraph::HyperGraphElement* element,
 							     HyperGraphElementAction::Parameters* params_) {
     if(typeid(*element).name() != _typeName) {
-      return 0;
+      return nullptr;
     }
 
     refreshPropertyPtrs(params_);

--- a/g2o/types/slam3d_addons/vertex_plane.cpp
+++ b/g2o/types/slam3d_addons/vertex_plane.cpp
@@ -77,7 +77,7 @@ namespace g2o
                  HyperGraphElementAction::Parameters* params_)
   {
     if (typeid(*element).name()!=_typeName)
-      return 0;
+      return nullptr;
 
     refreshPropertyPtrs(params_);
     if (! _previousParams)


### PR DESCRIPTION
In several places in the code "return 0" is used when the return type is a pointer or a boolean. These have been changed so that nullptr is returned for pointers and false for booleans.
