### PR TITLE
Removed uneeded includes in the header files. 

### DIFF
--- a/g2o/apps/g2o_hierarchical/edge_creator.h
+++ b/g2o/apps/g2o_hierarchical/edge_creator.h
@@ -27,10 +27,9 @@
 #ifndef G2O_EDGE_CREATOR_
 #define G2O_EDGE_CREATOR_
 
-#include "g2o/core/sparse_optimizer.h"
-#include <Eigen/Core>
 #include <vector>
 
+#include "g2o/core/sparse_optimizer.h"
 #include "g2o_hierarchical_api.h"
 
 namespace g2o {

--- a/g2o/apps/g2o_hierarchical/edge_labeler.h
+++ b/g2o/apps/g2o_hierarchical/edge_labeler.h
@@ -28,7 +28,6 @@
 #define G2O_EDGE_LABELER_
 
 #include "g2o/core/sparse_optimizer.h"
-#include <Eigen/Core>
 
 #include "g2o_hierarchical_api.h"
 

--- a/g2o/apps/g2o_hierarchical/edge_types_cost_function.h
+++ b/g2o/apps/g2o_hierarchical/edge_types_cost_function.h
@@ -28,8 +28,8 @@
 #define G2O_EDGE_TYPES_COST_FUNCTION_
 
 #include <string>
-#include "g2o/core/sparse_optimizer.h"
 #include "g2o/core/hyper_dijkstra.h"
+#include "g2o/core/optimizable_graph.h"
 
 namespace g2o {
 

--- a/g2o/apps/g2o_simulator/simulator.h
+++ b/g2o/apps/g2o_simulator/simulator.h
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <set>
+#include <list>
 #include "g2o/config.h"
 #include "g2o/types/slam3d/types_slam3d.h"
 #include "g2o/stuff/sampler.h"

--- a/g2o/core/estimate_propagator.h
+++ b/g2o/core/estimate_propagator.h
@@ -32,7 +32,6 @@
 #include "g2o_core_api.h"
 
 #include <map>
-#include <set>
 #include <limits>
 
 #include <unordered_map>

--- a/g2o/core/factory.h
+++ b/g2o/core/factory.h
@@ -28,7 +28,6 @@
 #define G2O_FACTORY_H
 
 #include "g2o/config.h"
-#include "g2o/stuff/misc.h"
 #include "hyper_graph.h"
 #include "creators.h"
 
@@ -41,7 +40,6 @@
 
 namespace g2o {
 
-  class AbstractHyperGraphElementCreator;
   
   /**
    * \brief create vertices and edges based on TAGs in, for example, a file

--- a/g2o/core/hyper_graph.h
+++ b/g2o/core/hyper_graph.h
@@ -27,12 +27,10 @@
 #ifndef G2O_AIS_HYPER_GRAPH_HH
 #define G2O_AIS_HYPER_GRAPH_HH
 
-#include <map>
 #include <set>
 #include <bitset>
 #include <cassert>
 #include <vector>
-#include <limits>
 #include <cstddef>
 
 #include <unordered_map>

--- a/g2o/core/hyper_graph_action.cpp
+++ b/g2o/core/hyper_graph_action.cpp
@@ -31,6 +31,7 @@
 
 
 #include <iostream>
+#include <list>
 
 namespace g2o {
   using namespace std;

--- a/g2o/core/hyper_graph_action.h
+++ b/g2o/core/hyper_graph_action.h
@@ -32,7 +32,6 @@
 
 #include <typeinfo>
 #include <iosfwd>
-#include <set>
 #include <string>
 #include <iostream>
 

--- a/g2o/core/marginal_covariance_cholesky.h
+++ b/g2o/core/marginal_covariance_cholesky.h
@@ -27,10 +27,8 @@
 #ifndef G2O_MARGINAL_COVARIANCE_CHOLESKY_H
 #define G2O_MARGINAL_COVARIANCE_CHOLESKY_H
 
-#include "optimizable_graph.h"
 #include "sparse_block_matrix.h"
 
-#include <cassert>
 #include <vector>
 
 #include <unordered_map>

--- a/g2o/core/optimizable_graph.h
+++ b/g2o/core/optimizable_graph.h
@@ -29,9 +29,6 @@
 
 #include <set>
 #include <iostream>
-#include <list>
-#include <limits>
-#include <cmath>
 #include <typeinfo>
 
 #include "openmp_mutex.h"
@@ -47,7 +44,6 @@ namespace g2o {
 
   class HyperGraphAction;
   struct OptimizationAlgorithmProperty;
-  class Cache;
   class CacheContainer;
   class RobustKernel;
 

--- a/g2o/core/optimization_algorithm_factory.h
+++ b/g2o/core/optimization_algorithm_factory.h
@@ -28,12 +28,10 @@
 #define G2O_OPTMIZATION_ALGORITHM_PROPERTY_H
 
 #include "g2o/config.h"
-#include "g2o/stuff/misc.h"
 #include "optimization_algorithm_property.h"
 
 #include <list>
 #include <iostream>
-#include <typeinfo>
 
 #include "g2o_core_api.h"
 
@@ -44,7 +42,6 @@ namespace g2o {
 
   // forward decl
   class G2O_CORE_API OptimizationAlgorithm;
-  class G2O_CORE_API SparseOptimizer;
 
   /**
    * \brief base for allocating an optimization algorithm

--- a/g2o/core/robust_kernel.h
+++ b/g2o/core/robust_kernel.h
@@ -28,7 +28,6 @@
 #define G2O_ROBUST_KERNEL_H
 
 #include <memory>
-#include <Eigen/Core>
 
 #include "g2o_core_api.h"
 

--- a/g2o/core/robust_kernel_factory.h
+++ b/g2o/core/robust_kernel_factory.h
@@ -28,7 +28,6 @@
 #define G2O_ROBUST_KERNEL_FACTORY_H
 
 #include "g2o_core_api.h"
-#include "g2o/stuff/misc.h"
 
 #include <string>
 #include <map>

--- a/g2o/core/solver.h
+++ b/g2o/core/solver.h
@@ -28,7 +28,6 @@
 #define G2O_SOLVER_H
 
 #include "hyper_graph.h"
-#include "batch_stats.h"
 #include "sparse_block_matrix.h"
 #include "g2o_core_api.h"
 #include <cstddef>

--- a/g2o/core/sparse_optimizer.h
+++ b/g2o/core/sparse_optimizer.h
@@ -34,12 +34,10 @@
 #include "g2o_core_api.h"
 #include "batch_stats.h"
 
-#include <map>
 
 namespace g2o {
 
   // forward declaration
-  class ActivePathCostFunction;
   class OptimizationAlgorithm;
   class EstimatePropagatorCost;
 

--- a/g2o/stuff/command_args.h
+++ b/g2o/stuff/command_args.h
@@ -30,7 +30,6 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <sstream>
 
 #include "g2o_stuff_api.h"
 

--- a/g2o/stuff/sampler.h
+++ b/g2o/stuff/sampler.h
@@ -28,7 +28,6 @@
 #define G2O_GAUSSIAN_SAMPLER_
 
 #include <Eigen/Core>
-#include <Eigen/Cholesky>
 #include <Eigen/StdVector>
 
 #include <cstdlib>

--- a/g2o/types/slam2d/edge_se2_pointxy_offset.h
+++ b/g2o/types/slam2d/edge_se2_pointxy_offset.h
@@ -31,7 +31,6 @@
 
 #include "vertex_se2.h"
 #include "vertex_point_xy.h"
-#include "parameter_se2_offset.h"
 #include "g2o_types_slam2d_api.h"
 
 namespace g2o {

--- a/g2o/types/slam2d/parameter_se2_offset.h
+++ b/g2o/types/slam2d/parameter_se2_offset.h
@@ -27,14 +27,11 @@
 #ifndef G2O_VERTEX_SE2_OFFSET_PARAMETERS_H_
 #define G2O_VERTEX_SE2_OFFSET_PARAMETERS_H_
 
-#include "g2o/core/optimizable_graph.h"
 
 #include "se2.h"
 #include "g2o_types_slam2d_api.h"
-#include "g2o/core/hyper_graph_action.h"
 #include "g2o/core/cache.h"
 
-#include <Eigen/Geometry>
 
 namespace g2o {
 

--- a/g2o/types/slam3d/edge_se3_offset.h
+++ b/g2o/types/slam3d/edge_se3_offset.h
@@ -27,9 +27,7 @@
 #ifndef G2O_EDGE_SE3_OFFSET_H_
 #define G2O_EDGE_SE3_OFFSET_H_
 
-#include "g2o/core/base_binary_edge.h"
 
-#include "vertex_se3.h"
 #include "edge_se3.h"
 #include "g2o_types_slam3d_api.h"
 

--- a/g2o/types/slam3d/isometry3d_gradients.h
+++ b/g2o/types/slam3d/isometry3d_gradients.h
@@ -27,12 +27,10 @@
 #ifndef G2O_ISOMETRY3D_GRADIENTS_H_
 #define G2O_ISOMETRY3D_GRADIENTS_H_
 
-#include "g2o_types_slam3d_api.h"
 #include "isometry3d_mappings.h"
 #include "dquat2mat.h"
 
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 
 namespace g2o {
   namespace internal {

--- a/g2o/types/slam3d/isometry3d_mappings.h
+++ b/g2o/types/slam3d/isometry3d_mappings.h
@@ -30,7 +30,6 @@
 #include "g2o_types_slam3d_api.h"
 #include "se3quat.h"
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 
 namespace g2o {
 

--- a/g2o/types/slam3d/parameter_se3_offset.h
+++ b/g2o/types/slam3d/parameter_se3_offset.h
@@ -27,17 +27,14 @@
 #ifndef G2O_VERTEX_SE3_OFFSET_PARAMETERS_H_
 #define G2O_VERTEX_SE3_OFFSET_PARAMETERS_H_
 
-#include "g2o/core/optimizable_graph.h"
 
 #include "g2o/core/hyper_graph_action.h"
 #include "g2o/core/cache.h"
 #include "g2o_types_slam3d_api.h"
 
-#include <Eigen/Geometry>
 
 namespace g2o {
 
-  class VertexSE3;
 
   /**
    * \brief offset for an SE3

--- a/g2o/types/slam3d_addons/edge_se3_calib.cpp
+++ b/g2o/types/slam3d_addons/edge_se3_calib.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se3_calib.h"
 
+#include "g2o/types/slam3d/vertex_se3.h"
+
 namespace g2o {
 
   EdgeSE3Calib::EdgeSE3Calib() :

--- a/g2o/types/slam3d_addons/edge_se3_calib.h
+++ b/g2o/types/slam3d_addons/edge_se3_calib.h
@@ -29,9 +29,7 @@
 
 #include "g2o_types_slam3d_addons_api.h"
 #include "g2o/core/base_multi_edge.h"
-#include "g2o/types/slam3d/vertex_se3.h"
 #include "g2o/types/slam3d/isometry3d_mappings.h"
-#include "Eigen/Geometry"
 
 namespace g2o
 {

--- a/g2o/types/slam3d_addons/line3d.cpp
+++ b/g2o/types/slam3d_addons/line3d.cpp
@@ -26,6 +26,8 @@
 
 #include "line3d.h"
 
+#include "g2o/stuff/misc.h"
+
 namespace g2o {
 
   using namespace std;

--- a/g2o/types/slam3d_addons/line3d.h
+++ b/g2o/types/slam3d_addons/line3d.h
@@ -27,13 +27,10 @@
 #ifndef G2O_LINE3D_H_
 #define G2O_LINE3D_H_
 
-#include <math.h>
 
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 
 #include "g2o_types_slam3d_addons_api.h"
-#include "g2o/stuff/misc.h"
 
 namespace g2o {
   

--- a/g2o/types/slam3d_addons/vertex_line3d.cpp
+++ b/g2o/types/slam3d_addons/vertex_line3d.cpp
@@ -26,6 +26,7 @@
 
 #include "vertex_line3d.h"
 
+#include "g2o/stuff/misc.h"
 #include "g2o/stuff/opengl_wrapper.h"
 
 namespace g2o {


### PR DESCRIPTION
I have been trying to improve the compilation time of using g2o in my library. Thus as a minor first step I removed all the unneeded includes in the header files found via the [iwyu](https://include-what-you-use.org/). I also removed a couple of forward declarations that were no longer being used. 