### PR TITLE
Fix for memory corruption and core dumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ endif()
 
 # Compiler specific options for gcc
 if(CMAKE_COMPILER_IS_GNUCXX)
-  option (BUILD_WITH_MARCH_NATIVE "Build with \"-march native\"" ON)
+  option (BUILD_WITH_MARCH_NATIVE "Build with \"-march native\"" OFF)
   message(STATUS "Compiling with GCC")
 
   # Generic settings for optimisation


### PR DESCRIPTION
This fixed a similar problem I ran into which is reported in #166. Might also fix #309.

Disable `-march native` because this will enable -mavx or -mavx2 on supported systems which override their corresponding -msse1/2/3/4 versions and lead to crashes whenever an external binary (which links g2o) is compiled with e.g. -msse4.2 and not -mavx/-mavx2

Eigen code compiled with -msse4.2 will be 16 bit aligned and Eigen code compiled with -avx will be 32bit aligned. If you have a binary compiled with -msee4.2 and create an Eigen::Isometry3d it will be 16bit memory aligned. If you pass this matrix to a library that expects a 32bit aligned Eigen::Isometry3d (because of AVX) there is a high chance that you get a memory corruption and a crash!

Other option might be to document this and make it clear that everyone has to compile dependent code
with the same optimizations! 