### PR TITLE
Fixed a bug of ba_demo and sba_demo. Use robust chi2 in struct_only_solver.

### DIFF
--- a/g2o/examples/ba/ba_demo.cpp
+++ b/g2o/examples/ba/ba_demo.cpp
@@ -265,7 +265,7 @@ int main(int argc, const char* argv[]){
   cout << "Performing full BA:" << endl;
   optimizer.optimize(10);
   cout << endl;
-  cout << "Point error before optimisation (inliers only): " << sqrt(sum_diff2/point_num) << endl;
+  cout << "Point error before optimisation (inliers only): " << sqrt(sum_diff2/inliers.size()) << endl;
   point_num = 0;
   sum_diff2 = 0;
   for (unordered_map<int,int>::iterator it=pointid_2_trueid.begin();
@@ -288,6 +288,6 @@ int main(int argc, const char* argv[]){
     sum_diff2 += diff.dot(diff);
     ++point_num;
   }
-  cout << "Point error after optimisation (inliers only): " << sqrt(sum_diff2/point_num) << endl;
+  cout << "Point error after optimisation (inliers only): " << sqrt(sum_diff2/inliers.size()) << endl;
   cout << endl;
 }

--- a/g2o/examples/sba/sba_demo.cpp
+++ b/g2o/examples/sba/sba_demo.cpp
@@ -357,7 +357,7 @@ int main(int argc, const char* argv[])
   optimizer.optimize(10);
 
   cout << endl;
-  cout << "Point error before optimisation (inliers only): " << sqrt(sum_diff2/point_num) << endl;
+  cout << "Point error before optimisation (inliers only): " << sqrt(sum_diff2/inliers.size()) << endl;
 
 
   point_num = 0;
@@ -396,7 +396,7 @@ int main(int argc, const char* argv[])
     ++point_num;
   }
 
-  cout << "Point error after optimisation (inliers only): " << sqrt(sum_diff2/point_num) << endl;
+  cout << "Point error after optimisation (inliers only): " << sqrt(sum_diff2/inliers.size()) << endl;
   cout << endl;
 
 }

--- a/g2o/solvers/structure_only/structure_only_solver.h
+++ b/g2o/solvers/structure_only/structure_only_solver.h
@@ -89,7 +89,16 @@ class StructureOnlySolver : public OptimizationAlgorithm
         for (g2o::HyperGraph::EdgeSet::iterator it_t=track.begin(); it_t!=track.end(); ++it_t) {
           g2o::OptimizableGraph::Edge* e = dynamic_cast<g2o::OptimizableGraph::Edge *>(*it_t);
           e->computeError();
-          chi2 += e->chi2();
+          if (e->robustKernel())
+          {
+            Vector3 rho;
+            e->robustKernel()->robustify(e->chi2(), rho);
+            chi2 += rho[0];
+          }
+          else
+          {
+            chi2 += e->chi2();
+          }
         }
 
         if (v->fixed() == false) {
@@ -155,7 +164,16 @@ class StructureOnlySolver : public OptimizationAlgorithm
                 for (g2o::HyperGraph::EdgeSet::iterator it_t=track.begin(); it_t!=track.end(); ++it_t) {
                   g2o::OptimizableGraph::Edge* e = dynamic_cast<g2o::OptimizableGraph::Edge *>(*it_t);
                   e->computeError();
-                  new_chi2 += e->chi2();
+                  if (e->robustKernel())
+                  {
+                    Vector3 rho;
+                    e->robustKernel()->robustify(e->chi2(), rho);
+                    new_chi2 += rho[0];
+                  }
+                  else
+                  {
+                    new_chi2 += e->chi2();
+                  }
                 }
                 assert(g2o_isnan(new_chi2)==false && "Chi is NaN");
                 number_t rho = (chi2 - new_chi2);


### PR DESCRIPTION
#### 1. Fix bugs in ba_demo.cpp and sba_demo.cpp.
Divider should be inlier number instead of all point number when computing average point error. Current output of error before optimization is wrong. 

#### 2.Consider the case when edge has a robust kernel.
The chi2 used to dicide a good step should be robust chi2 when the edge has a robust kernel. Current code does not consider this case, while meantime, robust kernel is considered in every iteration of optimization. It leads to different criteria inside and outside every iteration.