### PR TITLE
Fix deadlock in multi edges too

### DIFF
--- a/g2o/core/base_binary_edge.hpp
+++ b/g2o/core/base_binary_edge.hpp
@@ -24,27 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-namespace {
-
-#ifdef G2O_OPENMP
-struct QuadraticFormLock {
-  explicit QuadraticFormLock(OptimizableGraph::Vertex& vertex) : _vertex(vertex) {
-    _vertex.lockQuadraticForm();
-  }
-  ~QuadraticFormLock() {
-    _vertex.unlockQuadraticForm();
-  }
-private:
-  OptimizableGraph::Vertex& _vertex;
-};
-#else
-struct QuadraticFormLock {
-  explicit QuadraticFormLock(OptimizableGraph::Vertex& ) { }
-};
-#endif
-
-} // anonymous namespace
-
 template <int D, typename E, typename VertexXiType, typename VertexXjType>
 OptimizableGraph::Vertex* BaseBinaryEdge<D, E, VertexXiType, VertexXjType>::createFrom(){
   return createVertex(0);

--- a/g2o/core/base_edge.h
+++ b/g2o/core/base_edge.h
@@ -35,6 +35,27 @@
 #include "optimizable_graph.h"
 
 namespace g2o {
+namespace {
+
+#ifdef G2O_OPENMP
+  struct QuadraticFormLock {
+    explicit QuadraticFormLock(OptimizableGraph::Vertex& vertex)
+        :_vertex(vertex) {
+      _vertex.lockQuadraticForm();
+    }
+    ~QuadraticFormLock() {
+      _vertex.unlockQuadraticForm();
+    }
+  private:
+    OptimizableGraph::Vertex& _vertex;
+  };
+#else
+  struct QuadraticFormLock {
+    explicit QuadraticFormLock(OptimizableGraph::Vertex& ) { }
+  };
+#endif
+
+} // anonymous namespace
 
   template <int D, typename E>
   class BaseEdge : public OptimizableGraph::Edge

--- a/g2o/core/base_multi_edge.hpp
+++ b/g2o/core/base_multi_edge.hpp
@@ -62,13 +62,6 @@ void BaseMultiEdge<D, E>::linearizeOplus(JacobianWorkspace& jacobianWorkspace)
 template <int D, typename E>
 void BaseMultiEdge<D, E>::linearizeOplus()
 {
-#ifdef G2O_OPENMP
-  for (size_t i = 0; i < _vertices.size(); ++i) {
-    OptimizableGraph::Vertex* v = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
-    v->lockQuadraticForm();
-  }
-#endif
-
   const number_t delta = cst(1e-9);
   const number_t scalar = 1 / (2*delta);
   ErrorVector errorBak;
@@ -80,46 +73,40 @@ void BaseMultiEdge<D, E>::linearizeOplus()
     //Xi - estimate the jacobian numerically
     OptimizableGraph::Vertex* vi = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
 
-    if (vi->fixed())
+    if (vi->fixed()) {
       continue;
+    } else {
+      QuadraticFormLock lck(*vi);
+      const int vi_dim = vi->dimension();
+      assert(vi_dim >= 0);
 
-    const int vi_dim = vi->dimension();
-    assert(vi_dim >= 0);
+      number_t* add_vi = buffer.request(vi_dim);
 
-    number_t* add_vi = buffer.request(vi_dim);
+      std::fill(add_vi, add_vi + vi_dim, cst(0.0));
+      assert(_dimension >= 0);
+      assert(_jacobianOplus[i].rows() == _dimension && _jacobianOplus[i].cols() == vi_dim && "jacobian cache dimension does not match");
+        _jacobianOplus[i].resize(_dimension, vi_dim);
+      // add small step along the unit vector in each dimension
+      for (int d = 0; d < vi_dim; ++d) {
+        vi->push();
+        add_vi[d] = delta;
+        vi->oplus(add_vi);
+        computeError();
+        errorBak = _error;
+        vi->pop();
+        vi->push();
+        add_vi[d] = -delta;
+        vi->oplus(add_vi);
+        computeError();
+        errorBak -= _error;
+        vi->pop();
+        add_vi[d] = 0.0;
 
-    std::fill(add_vi, add_vi + vi_dim, cst(0.0));
-    assert(_dimension >= 0);
-    assert(_jacobianOplus[i].rows() == _dimension && _jacobianOplus[i].cols() == vi_dim && "jacobian cache dimension does not match");
-      _jacobianOplus[i].resize(_dimension, vi_dim);
-    // add small step along the unit vector in each dimension
-    for (int d = 0; d < vi_dim; ++d) {
-      vi->push();
-      add_vi[d] = delta;
-      vi->oplus(add_vi);
-      computeError();
-      errorBak = _error;
-      vi->pop();
-      vi->push();
-      add_vi[d] = -delta;
-      vi->oplus(add_vi);
-      computeError();
-      errorBak -= _error;
-      vi->pop();
-      add_vi[d] = 0.0;
-
-      _jacobianOplus[i].col(d) = scalar * errorBak;
-    } // end dimension
+        _jacobianOplus[i].col(d) = scalar * errorBak;
+      } // end dimension
+    }
   }
   _error = errorBeforeNumeric;
-
-#ifdef G2O_OPENMP
-  for (int i = (int)(_vertices.size()) - 1; i >= 0; --i) {
-    OptimizableGraph::Vertex* v = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
-    v->unlockQuadraticForm();
-  }
-#endif
-
 }
 
 template <int D, typename E>
@@ -181,20 +168,19 @@ void BaseMultiEdge<D, E>::computeQuadraticForm(const InformationType& omega, con
       Eigen::Map<VectorX> fromB(from->bData(), fromDim);
 
       // ii block in the hessian
-#ifdef G2O_OPENMP
-      from->lockQuadraticForm();
-#endif
-      fromMap.noalias() += AtO * A;
-      fromB.noalias() += A.transpose() * weightedError;
+      {
+        QuadraticFormLock lck(*from);
+        fromMap.noalias() += AtO * A;
+        fromB.noalias() += A.transpose() * weightedError;
+      }
 
       // compute the off-diagonal blocks ij for all j
       for (size_t j = i+1; j < _vertices.size(); ++j) {
         OptimizableGraph::Vertex* to = static_cast<OptimizableGraph::Vertex*>(_vertices[j]);
-#ifdef G2O_OPENMP
-        to->lockQuadraticForm();
-#endif
+
         bool jstatus = !(to->fixed());
         if (jstatus) {
+          QuadraticFormLock lck(*to);
           const JacobianType& B = _jacobianOplus[j];
           int idx = internal::computeUpperTriangleIndex(i, j);
           assert(idx < (int)_hessian.size());
@@ -205,16 +191,8 @@ void BaseMultiEdge<D, E>::computeQuadraticForm(const InformationType& omega, con
             hhelper.matrix.noalias() += AtO * B;
           }
         }
-#ifdef G2O_OPENMP
-        to->unlockQuadraticForm();
-#endif
       }
-
-#ifdef G2O_OPENMP
-      from->unlockQuadraticForm();
-#endif
     }
-
   }
 }
 
@@ -251,13 +229,6 @@ void BaseMultiEdge<-1, E>::linearizeOplus(JacobianWorkspace& jacobianWorkspace)
 template <typename E>
 void BaseMultiEdge<-1, E>::linearizeOplus()
 {
-#ifdef G2O_OPENMP
-  for (size_t i = 0; i < _vertices.size(); ++i) {
-    OptimizableGraph::Vertex* v = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
-    v->lockQuadraticForm();
-  }
-#endif
-
   const number_t delta = cst(1e-9);
   const number_t scalar = 1 / (2*delta);
   ErrorVector errorBak;
@@ -269,46 +240,40 @@ void BaseMultiEdge<-1, E>::linearizeOplus()
     //Xi - estimate the jacobian numerically
     OptimizableGraph::Vertex* vi = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
 
-    if (vi->fixed())
+    if (vi->fixed()) {
       continue;
+    } else {
+      QuadraticFormLock lck(*vi);
+      const int vi_dim = vi->dimension();
+      assert(vi_dim >= 0);
 
-    const int vi_dim = vi->dimension();
-    assert(vi_dim >= 0);
+      number_t* add_vi = buffer.request(vi_dim);
 
-    number_t* add_vi = buffer.request(vi_dim);
+      std::fill(add_vi, add_vi + vi_dim, cst(0.0));
+      assert(_dimension >= 0);
+      assert(_jacobianOplus[i].rows() == _dimension && _jacobianOplus[i].cols() == vi_dim && "jacobian cache dimension does not match");
+      _jacobianOplus[i].resize(_dimension, vi_dim);
+      // add small step along the unit vector in each dimension
+      for (int d = 0; d < vi_dim; ++d) {
+        vi->push();
+        add_vi[d] = delta;
+        vi->oplus(add_vi);
+        computeError();
+        errorBak = _error;
+        vi->pop();
+        vi->push();
+        add_vi[d] = -delta;
+        vi->oplus(add_vi);
+        computeError();
+        errorBak -= _error;
+        vi->pop();
+        add_vi[d] = 0.0;
 
-    std::fill(add_vi, add_vi + vi_dim, cst(0.0));
-    assert(_dimension >= 0);
-    assert(_jacobianOplus[i].rows() == _dimension && _jacobianOplus[i].cols() == vi_dim && "jacobian cache dimension does not match");
-    _jacobianOplus[i].resize(_dimension, vi_dim);
-    // add small step along the unit vector in each dimension
-    for (int d = 0; d < vi_dim; ++d) {
-      vi->push();
-      add_vi[d] = delta;
-      vi->oplus(add_vi);
-      computeError();
-      errorBak = _error;
-      vi->pop();
-      vi->push();
-      add_vi[d] = -delta;
-      vi->oplus(add_vi);
-      computeError();
-      errorBak -= _error;
-      vi->pop();
-      add_vi[d] = 0.0;
-
-      _jacobianOplus[i].col(d) = scalar * errorBak;
-    } // end dimension
+        _jacobianOplus[i].col(d) = scalar * errorBak;
+      } // end dimension
+    }
   }
   _error = errorBeforeNumeric;
-
-#ifdef G2O_OPENMP
-  for (int i = (int)(_vertices.size()) - 1; i >= 0; --i) {
-    OptimizableGraph::Vertex* v = static_cast<OptimizableGraph::Vertex*>(_vertices[i]);
-    v->unlockQuadraticForm();
-  }
-#endif
-
 }
 
 template <typename E>
@@ -370,20 +335,18 @@ void BaseMultiEdge<-1, E>::computeQuadraticForm(const InformationType& omega, co
       Eigen::Map<VectorX> fromB(from->bData(), fromDim);
 
       // ii block in the hessian
-#ifdef G2O_OPENMP
-      from->lockQuadraticForm();
-#endif
-      fromMap.noalias() += AtO * A;
-      fromB.noalias() += A.transpose() * weightedError;
+      {
+        QuadraticFormLock lck(*from);
+        fromMap.noalias() += AtO * A;
+        fromB.noalias() += A.transpose() * weightedError;
+      }
 
       // compute the off-diagonal blocks ij for all j
       for (size_t j = i+1; j < _vertices.size(); ++j) {
         OptimizableGraph::Vertex* to = static_cast<OptimizableGraph::Vertex*>(_vertices[j]);
-#ifdef G2O_OPENMP
-        to->lockQuadraticForm();
-#endif
         bool jstatus = !(to->fixed());
         if (jstatus) {
+          QuadraticFormLock lck(*to);
           const JacobianType& B = _jacobianOplus[j];
           int idx = internal::computeUpperTriangleIndex(i, j);
           assert(idx < (int)_hessian.size());
@@ -394,15 +357,7 @@ void BaseMultiEdge<-1, E>::computeQuadraticForm(const InformationType& omega, co
             hhelper.matrix.noalias() += AtO * B;
           }
         }
-#ifdef G2O_OPENMP
-        to->unlockQuadraticForm();
-#endif
       }
-
-#ifdef G2O_OPENMP
-      from->unlockQuadraticForm();
-#endif
     }
-
   }
 }


### PR DESCRIPTION
The issue from 6ec231 wasn't unique for the binary edges.  
So, OpenMP deadlock was reproduced in multi edges, fixed with the same technique and tested intensively. 
```
commit 6ec231465afd460285e368c5a1b5d9358a2e2b68
Author: Artem Suleimanov <nevermore@yandex-team.ru>
Date:   Tue Feb 13 14:01:06 2018 +0300

    Fix deadlock occurences in binary edges
```