### PR TITLE
Fix bug, that sets the 2nd offset to the 1st

### DIFF
--- a/g2o/types/slam3d/edge_se3_offset.cpp
+++ b/g2o/types/slam3d/edge_se3_offset.cpp
@@ -51,7 +51,7 @@ namespace g2o {
     ParameterVector pv(2);
     pv[0]=_offsetFrom;
     resolveCache(_cacheFrom, (OptimizableGraph::Vertex*)_vertices[0],"CACHE_SE3_OFFSET",pv);
-    pv[1]=_offsetTo;
+    pv[0]=_offsetTo;
     resolveCache(_cacheTo, (OptimizableGraph::Vertex*)_vertices[1],"CACHE_SE3_OFFSET",pv);
     return (_cacheFrom && _cacheTo);
   }


### PR DESCRIPTION
"to" and "from" offsets are always equal.
Found during comparison with slam2d/edge_se2_offset.cpp that this value was different.
Tested the change and works now.

~~Please verify with the following graph (save as tmp.g2o, try g2o -o out.g2o tmp.g2o)~~
~~PARAMS_CAMERACALIB 0 1 2 3 0 0 0 1 500. 500. 320 240 
PARAMS_SE3OFFSET 1 0.1 0.2 0.3 0 0 0 1 
PARAMS_SE3OFFSET 2 1 2 3 0 0 0 1 
VERTEX_SE3:QUAT 0 0.1 0.2 0.3 0 0 0 1 
VERTEX_SE3:QUAT 1 0.2 0.3 0.4 0 0 0 1 
EDGE_SE3_OFFSET 0 1 1 2 0.1 0.1 0.1 0.0 0.0 0.0 1.0 1 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0 0 1 0 1~~
