### PR TITLE
Fix recursive dependencies when using CMake targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,15 +352,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${g2o_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${g2o_C_FLAGS}")
 
-# Find Eigen3. First try to find it using the configuration file form
-# because this is our target of choice. If this fails, fall back to the
-# using the module form.
+# Find Eigen3. If it defines the target, this is used. If not,
+# fall back to the using the module form.
 # See https://eigen.tuxfamily.org/dox/TopicCMakeGuide.html for details
-find_package(Eigen3 NO_MODULE)
+find_package(Eigen3 REQUIRED)
 if (TARGET Eigen3::Eigen)
   set(G2O_EIGEN3_EIGEN_TARGET Eigen3::Eigen)
 else()
-  find_package(Eigen3 REQUIRED)
   include_directories(${EIGEN3_INCLUDE_DIR})
 endif ()
 

--- a/cmake_modules/Config.cmake.in
+++ b/cmake_modules/Config.cmake.in
@@ -1,2 +1,7 @@
-@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Eigen3)
+find_dependency(OpenGL)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@G2O_TARGETS_EXPORT_NAME@.cmake")
+


### PR DESCRIPTION
The first change is basically to simplify the handling of Eigen3 a bit. (Instead of preferring the targets, use whatever is found first on the system.) That way it is consistent with how OpenGL is found shortly before.

Second change is so that other packages depending on g2o can actually resolve the targets used throughout CMake. Whenever other targets are linked to g2o-targets, the respective packages should also go into the g2oConfig.cmake.