### PR TITLE
Added ~QuadraticFormLock to prevent unused variable warnings

### DIFF
--- a/g2o/core/base_edge.h
+++ b/g2o/core/base_edge.h
@@ -53,6 +53,7 @@ namespace g2o {
   #else
     struct QuadraticFormLock {
       explicit QuadraticFormLock(OptimizableGraph::Vertex& ) { }
+      ~QuadraticFormLock() { }
     };
   #endif
 


### PR DESCRIPTION
For undefined `G2O_OPENMP` gcc-7 complains about unused variables without an explicit dummy destructor 
```
external/g2o/g2o/core/base_binary_edge.hpp:83:39: warning: unused variable 'lck' [-Wunused-variable]
          internal::QuadraticFormLock lck(*from);
```

Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=17006#c1