### PR TITLE
fix bug in SE3Quat::log

### DIFF
--- a/g2o/types/slam3d/se3quat.h
+++ b/g2o/types/slam3d/se3quat.h
@@ -181,7 +181,7 @@ namespace g2o {
         Vector3 dR = deltaR(_R);
         Matrix3 V_inv;
 
-        if (d>cst(0.99999))
+        if (std::abs(d)>cst(0.99999))
         {
 
           omega=0.5*dR;


### PR DESCRIPTION
The value of  d  is not checked against values close to  -1. Hence, an rotation
with angle close to  pi  fails the check for performing the taylor approximation
based computation in the default case and enters the else case. However, here
one divides by  sqrt(1-d*d)  resulting in  inf  and  nan  for rotation and
translation elements of the resulting Vector6d. Checking the absolute value of
d  in the first place solves this issue.