### PR TITLE
Homebrew formula path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ following packages.
 #### Mac OS X
 If using [Homebrew](http://brew.sh/), then
 
-`brew install homebrew/science/g2o`
+`brew install brewsci/science/g2o`
 
 will install g2o together with its required dependencies. In this case no manual compilation is necessary.
 


### PR DESCRIPTION
Homebrew tap `homebrew/science` has been migrated to `brewsci/science`: [Homebrew/science has moved to Brewsci/bio and Brewsci/science · Issue #6617 · Homebrew/homebrew-scie](https://github.com/Homebrew/homebrew-science/issues/6617#issue-288173302) .