### PR TITLE
Update isometry3d_gradients.h

### DIFF
--- a/g2o/types/slam3d/isometry3d_gradients.h
+++ b/g2o/types/slam3d/isometry3d_gradients.h
@@ -266,7 +266,7 @@ namespace g2o {
                                    const Eigen::MatrixBase<Derived>& JConstRef, 
                                    const Isometry3& Z, 
                                    const Isometry3& X,
-                                   const Isometry3& P=Isometry3())
+                                   const Isometry3& P=Isometry3::Identity())
   {
     Eigen::MatrixBase<Derived>& J = const_cast<Eigen::MatrixBase<Derived>&>(JConstRef);
     J.derived().resize(6,6);


### PR DESCRIPTION
The default constructor does not initialize the coefficients.
(see https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html#a19d71151dfbbe89db15961c93726dd70 )