### PR TITLE
Remove Eigen/StdVector includes and fix mingw-w64 compilation

### DIFF
--- a/g2o/core/base_multi_edge.h
+++ b/g2o/core/base_multi_edge.h
@@ -31,8 +31,6 @@
 #include <iomanip>
 #include <limits>
 
-#include <Eigen/StdVector>
-
 #include "base_edge.h"
 #include "robust_kernel.h"
 #include "g2o/config.h"

--- a/g2o/core/base_vertex.h
+++ b/g2o/core/base_vertex.h
@@ -34,7 +34,6 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/Cholesky>
-#include <Eigen/StdVector>
 #include <stack>
 
 namespace g2o {

--- a/g2o/core/jacobian_workspace.h
+++ b/g2o/core/jacobian_workspace.h
@@ -28,7 +28,6 @@
 #define JACOBIAN_WORKSPACE_H
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include <vector>
 #include <cassert>

--- a/g2o/core/sparse_block_matrix_diagonal.h
+++ b/g2o/core/sparse_block_matrix_diagonal.h
@@ -29,7 +29,6 @@
 
 #include <vector>
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include "g2o/config.h"
 #include "matrix_operations.h"

--- a/g2o/examples/ba/ba_demo.cpp
+++ b/g2o/examples/ba/ba_demo.cpp
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <Eigen/StdVector>
 #include <iostream>
 #include <stdint.h>
 

--- a/g2o/examples/ba_anchored_inverse_depth/ba_anchored_inverse_depth_demo.cpp
+++ b/g2o/examples/ba_anchored_inverse_depth/ba_anchored_inverse_depth_demo.cpp
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <Eigen/StdVector>
 #include <iostream>
 #include <stdint.h>
 

--- a/g2o/examples/bal/bal_example.cpp
+++ b/g2o/examples/bal/bal_example.cpp
@@ -25,7 +25,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 #include <Eigen/Geometry>
 #include <iostream>
 

--- a/g2o/examples/calibration_odom_laser/motion_information.h
+++ b/g2o/examples/calibration_odom_laser/motion_information.h
@@ -28,7 +28,6 @@
 #define G2O_MOTION_INFORMATION_H
 
 #include <vector>
-#include <Eigen/StdVector>
 
 #include "g2o/types/slam2d/se2.h"
 #include "g2o_calibration_odom_laser_api.h"

--- a/g2o/examples/data_fitting/circle_fit.cpp
+++ b/g2o/examples/data_fitting/circle_fit.cpp
@@ -25,7 +25,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 #include <Eigen/Geometry>
 #include <iostream>
 

--- a/g2o/examples/icp/gicp_demo.cpp
+++ b/g2o/examples/icp/gicp_demo.cpp
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <Eigen/StdVector>
 #include <random>
 #include <iostream>
 #include <stdint.h>

--- a/g2o/examples/icp/gicp_sba_demo.cpp
+++ b/g2o/examples/icp/gicp_sba_demo.cpp
@@ -24,7 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <Eigen/StdVector>
 #include <random>
 #include <iostream>
 #include <stdint.h>

--- a/g2o/examples/interactive_slam/g2o_incremental/g2o_incremental.cpp
+++ b/g2o/examples/interactive_slam/g2o_incremental/g2o_incremental.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv)
     vector<EdgeInformation> edgesFromGraph;
 
     // HACK force tictoc statistics
-#ifdef _MSC_VER
+#if defined _MSC_VER || defined __MINGW32__
     _putenv_s("G2O_ENABLE_TICTOC", "1");
 #else
     setenv("G2O_ENABLE_TICTOC", "1", 1);

--- a/g2o/examples/sba/sba_demo.cpp
+++ b/g2o/examples/sba/sba_demo.cpp
@@ -24,8 +24,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <Eigen/StdVector>
-
 #include <unordered_set>
 
 #include <iostream>

--- a/g2o/examples/sphere/create_sphere.cpp
+++ b/g2o/examples/sphere/create_sphere.cpp
@@ -30,7 +30,6 @@
 #include <cmath>
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include "g2o/types/slam3d/vertex_se3.h"
 #include "g2o/types/slam3d/edge_se3.h"

--- a/g2o/examples/target/constant_velocity_target.cpp
+++ b/g2o/examples/target/constant_velocity_target.cpp
@@ -28,7 +28,6 @@
 // moves under piecewise constant velocity in 3D. Its position is
 // measured by an idealised GPS receiver.
 
-#include <Eigen/StdVector>
 #include <iostream>
 
 #include <stdint.h>

--- a/g2o/examples/target/static_target.cpp
+++ b/g2o/examples/target/static_target.cpp
@@ -28,7 +28,6 @@
 // place and does not move; in effect it has a "GPS" which measures
 // its position
 
-#include <Eigen/StdVector>
 #include <iostream>
 #include <stdint.h>
  

--- a/g2o/examples/tutorial_slam2d/simulator.h
+++ b/g2o/examples/tutorial_slam2d/simulator.h
@@ -30,8 +30,6 @@
 #include "se2.h"
 #include "g2o_tutorial_slam2d_api.h"
 
-#include <Eigen/StdVector>
-
 #include <vector>
 #include <map>
 

--- a/g2o/solvers/pcg/linear_solver_pcg.h
+++ b/g2o/solvers/pcg/linear_solver_pcg.h
@@ -33,10 +33,6 @@
 #include <vector>
 #include <utility>
 #include<Eigen/Core>
-//#ifndef EIGEN_USE_NEW_STDVECTOR
-//#define EIGEN_USE_NEW_STDVECTOR
-//#endif
-#include<Eigen/StdVector>
 
 namespace g2o {
 

--- a/g2o/stuff/sampler.h
+++ b/g2o/stuff/sampler.h
@@ -28,7 +28,6 @@
 #define G2O_GAUSSIAN_SAMPLER_
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include <cstdlib>
 #include <cmath>

--- a/g2o/stuff/unscented.h
+++ b/g2o/stuff/unscented.h
@@ -29,7 +29,6 @@
 
 #include <Eigen/Core>
 #include <Eigen/Cholesky>
-#include<Eigen/StdVector>
 
 namespace g2o {
   

--- a/g2o/types/data/raw_laser.h
+++ b/g2o/types/data/raw_laser.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 #include<Eigen/Core>
-#include<Eigen/StdVector>
 
 namespace g2o {
 


### PR DESCRIPTION
This removes all `#include <Eigen/StdVector>`, which are not needed on `C++11` and above. I was having issues compiling a different code which uses g2o, and I discovered it was caused by the inclusion of `Eigen/StdVector` in g2o. 

I figured this is okay, since you require `C++11`: https://github.com/RainerKuemmerle/g2o/blob/master/CMakeLists.txt#L348

This PR also fixes a compilation issue with mingw-w64 (see the change to `g2o/examples/interactive_slam/g2o_incremental/g2o_incremental.cpp`)