### PR TITLE
Fix a typo

### DIFF
--- a/doc/g2o.tex
+++ b/doc/g2o.tex
@@ -864,7 +864,7 @@ parameters of the algorithms can be controlled.
 \gopt{} includes an experimental binary for performing optimization in
 an incremental fashion, i.e., optimizing after inserting one or several
 nodes along with their measurements. In this case, \gopt{} performs
-ranke updates on the Hessian matrix to update the linear system. Please
+rank updates on the Hessian matrix to update the linear system. Please
 see the \verb+README+ in the \verb+g2o_incremental+ sub-folder for
 additional information.
 


### PR DESCRIPTION
Fix a typo: ranke -> rank. 