### PR TITLE
Fix a typo.

### DIFF
--- a/g2o/core/hyper_graph.h
+++ b/g2o/core/hyper_graph.h
@@ -238,14 +238,14 @@ namespace g2o {
       virtual bool addVertex(Vertex* v);
 
       /**
-       * Adds an edge  to the graph. If the edge is already in the graph, it
+       * Adds an edge to the graph. If the edge is already in the graph, it
        * does nothing and returns false. Otherwise it returns true.
        */
       virtual bool addEdge(Edge* e);
 
 
       /**
-       * Sets the vertex un position "pos" within the edge and keeps the bookkeeping consistent.
+       * Sets the vertex in position "pos" within the edge and keeps the bookkeeping consistent.
        * If v ==0, the vertex is set to "invalid"
        */
       virtual bool setEdgeVertex(Edge* e, int pos, Vertex* v);


### PR DESCRIPTION
Typo: un -> in.