### PR TITLE
msvc (debug config) multiple definition error fix

### DIFF
--- a/g2o/types/sim3/types_seven_dof_expmap.h
+++ b/g2o/types/sim3/types_seven_dof_expmap.h
@@ -50,6 +50,11 @@
 #endif
 namespace g2o {
 
+// explicit instantiation of BaseVertex, if not instantiated causes already defined error in some cases (msvc debug only)
+// see links below
+// https://stackoverflow.com/questions/44960760/msvc-dll-exporting-class-that-inherits-from-template-cause-lnk2005-already-defin
+// https://developercommunity.visualstudio.com/content/problem/224597/linker-failing-because-of-multiple-definitions-of.html
+template class BaseVertex<7, Sim3>;
 
 /**
  * \brief Sim3 Vertex, (x,y,z,qw,qx,qy,qz)


### PR DESCRIPTION
HI,

I have came across a strange multiple definition error compiling ORB_SLAM3 with msvc in debug configuration. This one line code solved the problem for me, it is very tricky to find, for more information please visit:

https://developercommunity.visualstudio.com/content/problem/224597/linker-failing-because-of-multiple-definitions-of.html
https://stackoverflow.com/questions/44960760/msvc-dll-exporting-class-that-inherits-from-template-cause-lnk2005-already-defin

thanks,
Csaba
