### PR TITLE
Avoid template specialization of BaseEdge

### DIFF
--- a/g2o/apps/g2o_viewer/CMakeLists.txt
+++ b/g2o/apps/g2o_viewer/CMakeLists.txt
@@ -8,7 +8,8 @@ if(Qt5_FOUND)
   set(MY_QT_LIBRARIES ${Qt5Widgets_LIBRARIES} ${Qt5Core_LIBRARIES} ${Qt5Gui_LIBRARIES} ${Qt5Xml_LIBRARIES} ${Qt5OpenGL_LIBRARIES})
 endif()
 
-include_directories(${QGLVIEWER_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(SYSTEM ${QGLVIEWER_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(viewer_library ${G2O_LIB_TYPE}
   g2o_viewer_api.h

--- a/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
+++ b/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
@@ -139,7 +139,7 @@ void G2oQGLViewer::init()
   setAxisIsDrawn();
 
   // don't save state
-  setStateFileName(QString::null);
+  setStateFileName(QString());
 
   // mouse bindings
 #ifdef QGLVIEWER_DEPRECATED_MOUSEBINDING

--- a/g2o/apps/g2o_viewer/gui_hyper_graph_action.cpp
+++ b/g2o/apps/g2o_viewer/gui_hyper_graph_action.cpp
@@ -2,17 +2,17 @@
 // Copyright (C) 2011 R. Kuemmerle, G. Grisetti, W. Burgard
 //
 // This file is part of g2o.
-// 
+//
 // g2o is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // g2o is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with g2o.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -21,6 +21,7 @@
 #include "g2o_qglviewer.h"
 
 #include <QApplication>
+#include <QtGlobal>
 
 namespace g2o {
 
@@ -46,7 +47,11 @@ HyperGraphAction* GuiHyperGraphAction::operator()(const HyperGraph* graph, Param
       if (p) {
         viewer->setSnapshotFormat(QString("PNG"));
         viewer->setSnapshotQuality(-1);
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
         viewer->saveSnapshot(QString().sprintf("g2o%.6d.png", p->iteration), true);
+#else
+        viewer->saveSnapshot(QString().asprintf("g2o%.6d.png", p->iteration), true);
+#endif
       }
     }
 

--- a/g2o/apps/g2o_viewer/main_window.cpp
+++ b/g2o/apps/g2o_viewer/main_window.cpp
@@ -2,17 +2,17 @@
 // Copyright (C) 2011 R. Kuemmerle, G. Grisetti, W. Burgard
 //
 // This file is part of g2o.
-// 
+//
 // g2o is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // g2o is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with g2o.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -222,7 +222,7 @@ void MainWindow::updateDisplayedSolvers()
     const OptimizationAlgorithmProperty& sp = (*it)->property();
     if (varFound && varType == sp.type)
       continue;
-    solverLookUp[sp.type].push_back(sp); 
+    solverLookUp[sp.type].push_back(sp);
   }
 
   for (map<string, vector<OptimizationAlgorithmProperty> >::iterator it = solverLookUp.begin(); it != solverLookUp.end(); ++it) {
@@ -330,9 +330,9 @@ void MainWindow::setRobustKernel()
 {
   SparseOptimizer* optimizer = viewer->graph;
   bool robustKernel = cbRobustKernel->isChecked();
-  double huberWidth = leKernelWidth->text().toDouble();  
+  double huberWidth = leKernelWidth->text().toDouble();
   //odometry edges are those whose node ids differ by 1
-  
+
   bool onlyLoop = cbOnlyLoop->isChecked();
 
   if (robustKernel) {
@@ -353,7 +353,7 @@ void MainWindow::setRobustKernel()
         e->setRobustKernel(creator->construct());
         e->robustKernel()->setDelta(huberWidth);
       }
-    }    
+    }
   } else {
     for (SparseOptimizer::EdgeSet::const_iterator it = optimizer->edges().begin(); it != optimizer->edges().end(); ++it) {
       OptimizableGraph::Edge* e = static_cast<OptimizableGraph::Edge*>(*it);
@@ -454,7 +454,7 @@ void MainWindow::on_actionLoad_Viewer_State_triggered(bool)
   if (!filename.isEmpty()) {
     viewer->setStateFileName(filename);
     viewer->restoreStateFromFile();
-    viewer->setStateFileName(QString::null);
+    viewer->setStateFileName(QString());
     viewer->update();
     cerr << "Loaded state from " << filename.toStdString() << endl;
   }
@@ -466,7 +466,7 @@ void MainWindow::on_actionSave_Viewer_State_triggered(bool)
   if (!filename.isEmpty()) {
     viewer->setStateFileName(filename);
     viewer->saveStateToFile();
-    viewer->setStateFileName(QString::null);
+    viewer->setStateFileName(QString());
     cerr << "Saved state to " << filename.toStdString() << endl;
   }
 }

--- a/g2o/core/base_edge.h
+++ b/g2o/core/base_edge.h
@@ -57,6 +57,20 @@ namespace g2o {
     };
   #endif
 
+    template <int D>
+    struct BaseEdgeTraits {
+      static constexpr int Dimension = D;
+      typedef Eigen::Matrix<number_t, D, 1, Eigen::ColMajor> ErrorVector;
+      typedef Eigen::Matrix<number_t, D, D, Eigen::ColMajor> InformationType;
+    };
+
+    template <>
+    struct BaseEdgeTraits<-1> {
+      static constexpr int Dimension = -1;
+      typedef Eigen::Matrix<number_t, Eigen::Dynamic, 1, Eigen::ColMajor> ErrorVector;
+      typedef Eigen::Matrix<number_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> InformationType;
+    };
+
   } // internal namespace
 
   template <int D, typename E>
@@ -64,10 +78,10 @@ namespace g2o {
   {
     public:
 
-      static const int Dimension = D;
+      static constexpr int Dimension = internal::BaseEdgeTraits<D>::Dimension;
       typedef E Measurement;
-      typedef Eigen::Matrix<number_t, D, 1, Eigen::ColMajor> ErrorVector;
-      typedef Eigen::Matrix<number_t, D, D, Eigen::ColMajor> InformationType;
+      typedef typename internal::BaseEdgeTraits<D>::ErrorVector ErrorVector;
+      typedef typename internal::BaseEdgeTraits<D>::InformationType InformationType;
 
       BaseEdge() : OptimizableGraph::Edge()
       {
@@ -154,74 +168,6 @@ namespace g2o {
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
-
-
-  template<typename E>
-  class BaseEdge<-1,E> : public OptimizableGraph::Edge
-  {
-    public:
-
-      static const int Dimension = -1;
-      typedef E Measurement;
-      typedef Eigen::Matrix<number_t, Eigen::Dynamic, 1, Eigen::ColMajor> ErrorVector;
-      typedef Eigen::Matrix<number_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> InformationType;
-
-      BaseEdge() : OptimizableGraph::Edge(){
-
-      }
-
-      virtual ~BaseEdge() {}
-
-      virtual number_t chi2() const
-      {
-        return _error.dot(information()*_error);
-      }
-
-      virtual const number_t* errorData() const { return _error.data();}
-      virtual number_t* errorData() { return _error.data();}
-      const ErrorVector& error() const { return _error;}
-      ErrorVector& error() { return _error;}
-
-      //! information matrix of the constraint
-      const InformationType& information() const { return _information;}
-      InformationType& information() { return _information;}
-      void setInformation(const InformationType& information) { _information = information;}
-
-      virtual const number_t* informationData() const { return _information.data();}
-      virtual number_t* informationData() { return _information.data();}
-
-      //! accessor functions for the measurement represented by the edge
-      const Measurement& measurement() const { return _measurement;}
-      virtual void setMeasurement(const Measurement& m) { _measurement = m;}
-
-      virtual int rank() const {return _dimension;}
-
-      virtual void initialEstimate(const OptimizableGraph::VertexSet&, OptimizableGraph::Vertex*)
-      {
-        std::cerr << "inititialEstimate() is not implemented, please give implementation in your derived class" << std::endl;
-      }
-
-    protected:
-
-      Measurement _measurement;
-      InformationType _information;
-      ErrorVector _error;
-
-      /**
-       * calculate the robust information matrix by updating the information matrix of the error
-       */
-      InformationType robustInformation(const Vector3& rho)
-      {
-        InformationType result = rho[1] * _information;
-        //ErrorVector weightedErrror = _information * _error;
-        //result.noalias() += 2 * rho[2] * (weightedErrror * weightedErrror.transpose());
-        return result;
-      }
-
-    public:
-      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  };
-
 
 } // end namespace g2o
 

--- a/g2o/core/base_edge.h
+++ b/g2o/core/base_edge.h
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <limits>
+#include <type_traits>
 
 #include <Eigen/Core>
 
@@ -117,6 +118,18 @@ namespace g2o {
       virtual void initialEstimate(const OptimizableGraph::VertexSet&, OptimizableGraph::Vertex*)
       {
         std::cerr << "inititialEstimate() is not implemented, please give implementation in your derived class" << std::endl;
+      }
+
+      /**
+       * set the dimension for a dynamically sizeable error function.
+       * The member will not be declared for edges having a fixed size at compile time.
+       */
+      template <int Dim = D>
+      typename std::enable_if<Dim == -1, void>::type setDimension(int dim) {
+        _dimension = dim;
+        _information.resize(dim, dim);
+        _error.resize(dim, 1);
+        _measurement.resize(dim, 1);
       }
 
     protected:

--- a/g2o/examples/slam2d/CMakeLists.txt
+++ b/g2o/examples/slam2d/CMakeLists.txt
@@ -1,14 +1,14 @@
 # qt components used (also by qglviewer): Core Gui Xml OpenGL Widgets
-
-include_directories(${CSPARSE_INCLUDE_DIR}
+include_directories(SYSTEM
     ${QGLVIEWER_INCLUDE_DIR}
     ${Qt5Core_INCLUDE_DIRS}
     ${Qt5Gui_INCLUDE_DIRS}
     ${Qt5Xml_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
     ${Qt5OpenGL_INCLUDE_DIRS}
-    ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    ${CSPARSE_INCLUDE_DIR}
+)
+include_directories(${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 QT5_WRAP_UI(UI_HEADERS base_main_window.ui)
 QT5_WRAP_CPP(UI_SOURCES main_window.h)
@@ -33,9 +33,6 @@ if(Qt5_POSITION_INDEPENDENT_CODE)
     #       does not seem to work: This generates some libraries with -fPIE which is not enough for Qt...
 endif()
 
-
-
-
 target_link_libraries(slam2d_g2o core solver_csparse types_slam2d
     ${QGLVIEWER_LIBRARY}
     ${Qt5Core_LIBRARIES}
@@ -45,4 +42,3 @@ target_link_libraries(slam2d_g2o core solver_csparse types_slam2d
     ${Qt5OpenGL_LIBRARIES}
     ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY}
 )
-

--- a/g2o/examples/slam2d/slam2d_viewer.cpp
+++ b/g2o/examples/slam2d/slam2d_viewer.cpp
@@ -2,17 +2,17 @@
 // Copyright (C) 2011 R. Kuemmerle, G. Grisetti, W. Burgard
 //
 // This file is part of g2o.
-// 
+//
 // g2o is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // g2o is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with g2o.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -55,17 +55,17 @@ namespace {
       StandardCamera() : _standard(true) {};
 
       qglv_real zNear() const {
-        if (_standard) 
-          return 0.001f; 
-        else 
-          return Camera::zNear(); 
+        if (_standard)
+          return 0.001f;
+        else
+          return Camera::zNear();
       }
 
       qglv_real zFar() const
-      {  
-        if (_standard) 
-          return 1000.0f; 
-        else 
+      {
+        if (_standard)
+          return 1000.0f;
+        else
           return Camera::zFar();
       }
 
@@ -101,8 +101,8 @@ namespace {
     glPushMatrix();
     glTranslatef(p.x(), p.y(), 0.f);
 
-    const typename Derived::Scalar& a = cov(0, 0); 
-    const typename Derived::Scalar& b = cov(0, 1); 
+    const typename Derived::Scalar& a = cov(0, 0);
+    const typename Derived::Scalar& b = cov(0, 1);
     const typename Derived::Scalar& d = cov(1, 1);
 
     /* get eigen-values */
@@ -183,7 +183,7 @@ void Slam2DViewer::init()
 
   // some default settings i like
   glEnable(GL_LINE_SMOOTH);
-  glEnable(GL_BLEND); 
+  glEnable(GL_BLEND);
   glEnable(GL_DEPTH_TEST);
   glShadeModel(GL_SMOOTH);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -191,7 +191,7 @@ void Slam2DViewer::init()
   setAxisIsDrawn();
 
   // don't save state
-  setStateFileName(QString::null);
+  setStateFileName(QString());
 
   // mouse bindings
 #ifdef QGLVIEWER_DEPRECATED_MOUSEBINDING

--- a/g2o/types/slam2d/edge_se2_lotsofxy.h
+++ b/g2o/types/slam2d/edge_se2_lotsofxy.h
@@ -44,14 +44,6 @@ namespace g2o {
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
       EdgeSE2LotsOfXY();
 
-      void setDimension(int dimension_)
-      {
-        _dimension = dimension_;
-        _information.resize(dimension_, dimension_);
-        _error.resize(dimension_, 1);
-        _measurement.resize(dimension_, 1);
-      }
-
       void setSize(int vertices)
       {
         resize(vertices);

--- a/g2o/types/slam3d/edge_se3_lotsofxyz.h
+++ b/g2o/types/slam3d/edge_se3_lotsofxyz.h
@@ -44,19 +44,11 @@ namespace g2o{
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
       EdgeSE3LotsOfXYZ();
 
-      void setDimension(int dimension_){
-        _dimension = dimension_;
-        _information.resize(dimension_, dimension_);
-        _error.resize(dimension_, 1);
-        _measurement.resize(dimension_, 1);
-      }
-
       void setSize(int vertices){
         resize(vertices);
         _observedPoints = vertices-1;
         setDimension(_observedPoints*3);
       }
-
 
       virtual void computeError();
 


### PR DESCRIPTION
* use a traits template for the type definition to avoid duplication of
  code in the specialization of BaseEdge.