### PR TITLE
Fixed various cmake warnings.

### DIFF
--- a/cmake_modules/FindCSparse.cmake
+++ b/cmake_modules/FindCSparse.cmake
@@ -23,5 +23,5 @@ find_library(CSPARSE_LIBRARY NAMES cxsparse libcxsparse
   )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CSPARSE DEFAULT_MSG
+find_package_handle_standard_args(CSparse DEFAULT_MSG
   CSPARSE_INCLUDE_DIR CSPARSE_LIBRARY)

--- a/cmake_modules/FindCholmod.cmake
+++ b/cmake_modules/FindCholmod.cmake
@@ -88,7 +88,7 @@ if(CHOLMOD_LIBRARIES)
 endif(CHOLMOD_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CHOLMOD DEFAULT_MSG
+find_package_handle_standard_args(Cholmod DEFAULT_MSG
                                   CHOLMOD_INCLUDE_DIR CHOLMOD_LIBRARIES)
 
 mark_as_advanced(CHOLMOD_LIBRARIES)

--- a/cmake_modules/FindQGLViewer.cmake
+++ b/cmake_modules/FindQGLViewer.cmake
@@ -1,9 +1,10 @@
-find_package(Qt5 COMPONENTS Core Xml OpenGL Gui Widgets)
+find_package(Qt5 COMPONENTS Core Xml OpenGL Gui Widgets QUIET)
 if(NOT Qt5_FOUND)
   message("Qt5 not found. Install it and set Qt5_DIR accordingly")
   if (WIN32)
     message("  In Windows, Qt5_DIR should be something like C:/Qt/5.4/msvc2013_64_opengl/lib/cmake/Qt5")
   endif()
+  return()
 endif()
 
 find_path(QGLVIEWER_INCLUDE_DIR qglviewer.h
@@ -46,5 +47,5 @@ if(QGLVIEWER_LIBRARY_RELEASE)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(QGLVIEWER DEFAULT_MSG
+find_package_handle_standard_args(QGLViewer DEFAULT_MSG
   QGLVIEWER_INCLUDE_DIR QGLVIEWER_LIBRARY)


### PR DESCRIPTION
This fixes a number of cmake warnings of the form:

  The package name passed to `find_package_handle_standard_args` (QGLVIEWER)
  does not match the name of the calling package (QGLViewer).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.

In addition, it suppresses Qt5 warnings and will not look for QGLViewer if Qt5 is not installed.