### PR TITLE
Fixed Cholmod include dirs.

### DIFF
--- a/g2o/solvers/cholmod/CMakeLists.txt
+++ b/g2o/solvers/cholmod/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(solver_cholmod ${G2O_LIB_TYPE}
 )
 
 target_include_directories(solver_cholmod PUBLIC
-  $<BUILD_INTERFACE:${CHOLMOD_INCLUDES}>
+  ${CHOLMOD_INCLUDES}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/g2o/solvers/cholmod>)
 


### PR DESCRIPTION
Cholmod is required in public headers, so the include path should not be limited to BUILD_INTERFACE, because dependent libraries will need it as well.