### PR TITLE
Eigen estimate data setters and getters

### DIFF
--- a/g2o/core/optimizable_graph.h
+++ b/g2o/core/optimizable_graph.h
@@ -160,24 +160,22 @@ namespace g2o {
          * @return true on success
          */
         bool setEstimateData(const std::vector<number_t>& estimate) {
-#ifndef NDEBUG
           int dim = estimateDimension();
-          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
-#endif
+          if ((dim == -1) || (estimate.size() != std::size_t(dim)))
+	    return false;
           return setEstimateData(&estimate[0]);
         };
 
-	/**
-         * sets the initial estimate from an eigen type of number_t
+	        /**
+         * sets the initial estimate from an array of number_t
          * Implement setEstimateDataImpl()
          * @return true on success
          */
         template<typename Derived>
         bool setEstimateData(const Eigen::MatrixBase<Derived>& estimate) {
-#ifndef NDEBUG
           int dim = estimateDimension();
-          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
-#endif
+	  if ((dim == -1) || (estimate.size() != dim))
+	    return false;
           return setEstimateData(estimate.derived().data());
         };
 
@@ -200,7 +198,7 @@ namespace g2o {
         };
 
         /**
-         * writes the estimater to an eigen type of number_t
+         * writes the estimater to an array of number_t
          * @returns true on success
          */
         template<typename Derived>
@@ -240,10 +238,9 @@ namespace g2o {
          * @return true on success
          */
         bool setMinimalEstimateData(const std::vector<number_t>& estimate) {
-#ifndef NDEBUG
           int dim = minimalEstimateDimension();
-          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
-#endif
+          if ((dim == -1) || (estimate.size() != std::size_t(dim)))
+	    return false;
           return setMinimalEstimateData(&estimate[0]);
         };
 
@@ -254,11 +251,10 @@ namespace g2o {
          */
         template<typename Derived>
         bool setMinimalEstimateData(const Eigen::MatrixBase<Derived>& estimate) {
-#ifndef NDEBUG
           int dim = minimalEstimateDimension();
-          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
-#endif
-          return setMinimalEstimateData(estimate.data());
+          if ((dim == -1) || (estimate.size() != dim))
+	    return false;
+          return setMinimalEstimateData(estimate.derived().data());
         };
 
 	
@@ -281,7 +277,7 @@ namespace g2o {
         };
 
         /**
-         * writes the estimate to an eigen type of number_t
+         * writes the estimate to an eigen type number_t
          * @returns true on success
          */
         template<typename Derived>

--- a/g2o/core/optimizable_graph.h
+++ b/g2o/core/optimizable_graph.h
@@ -167,6 +167,20 @@ namespace g2o {
           return setEstimateData(&estimate[0]);
         };
 
+	/**
+         * sets the initial estimate from an eigen type of number_t
+         * Implement setEstimateDataImpl()
+         * @return true on success
+         */
+        template<typename Derived>
+        bool setEstimateData(const Eigen::MatrixBase<Derived>& estimate) {
+#ifndef NDEBUG
+          int dim = estimateDimension();
+          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
+#endif
+          return setEstimateData(estimate.derived().data());
+        };
+
         /**
          * writes the estimater to an array of number_t
          * @returns true on success
@@ -185,6 +199,28 @@ namespace g2o {
           return getEstimateData(&estimate[0]);
         };
 
+        /**
+         * writes the estimater to an eigen type of number_t
+         * @returns true on success
+         */
+        template<typename Derived>
+        bool getEstimateData(Eigen::MatrixBase<Derived>& estimate) const {
+          int dim = estimateDimension();
+          // If dim is -ve, getEstimateData is not implemented and fails
+          if (dim < 0)
+            return false;
+
+          // If the vector isn't the right size to store the estimate, try to resize it.
+          // This only works if the vector is dynamic. If it is static, fail.
+          if (estimate.size() != dim) {
+             if ((estimate.RowsAtCompileTime == Eigen::Dynamic) || (estimate.ColsAtCompileTime == Eigen::Dynamic))
+                estimate.derived().resize(dim);
+             else
+                return false;
+          }
+          return getEstimateData(estimate.derived().data());
+        };
+	
         /**
          * returns the dimension of the extended representation used by get/setEstimate(number_t*)
          * -1 if it is not supported
@@ -212,6 +248,21 @@ namespace g2o {
         };
 
         /**
+         * sets the initial estimate from an eigen type of number_t.
+         * Implement setMinimalEstimateDataImpl()
+         * @return true on success
+         */
+        template<typename Derived>
+        bool setMinimalEstimateData(const Eigen::MatrixBase<Derived>& estimate) {
+#ifndef NDEBUG
+          int dim = minimalEstimateDimension();
+          assert((dim == -1) || (estimate.size() == std::size_t(dim)));
+#endif
+          return setMinimalEstimateData(estimate.data());
+        };
+
+	
+        /**
          * writes the estimate to an array of number_t
          * @returns true on success
          */
@@ -223,13 +274,35 @@ namespace g2o {
          */
         virtual bool getMinimalEstimateData(std::vector<number_t>& estimate) const {
           int dim = minimalEstimateDimension();
-          if (dim < 0)
+         if (dim < 0)
             return false;
           estimate.resize(dim);
           return getMinimalEstimateData(&estimate[0]);
         };
 
         /**
+         * writes the estimate to an eigen type of number_t
+         * @returns true on success
+         */
+        template<typename Derived>
+        bool getMinimalEstimateData(Eigen::MatrixBase<Derived>& estimate) const {
+          int dim = minimalEstimateDimension();
+          // If dim is -ve, getMinimalEstimateData is not implemented and fails
+          if (dim < 0)
+            return false;
+
+          // If the vector isn't the right size to store the estimate, try to resize it.
+          // This only works if the vector is dynamic. If it is static, fail.
+          if (estimate.size() != dim) {
+             if ((estimate.RowsAtCompileTime == Eigen::Dynamic) || (estimate.ColsAtCompileTime == Eigen::Dynamic))
+                estimate.derived().resize(dim);
+             else
+                return false;
+          }
+          return getMinimalEstimateData(estimate.derived().data());
+        };
+
+	/**
          * returns the dimension of the extended representation used by get/setEstimate(number_t*)
          * -1 if it is not supported
          */


### PR DESCRIPTION
This small change adds the use of eigen types for get / set (minimal) estimate data for vertices. Since the methods use the eigen matrix block template, they can use eigen block operations.

The implementation for the other method used std::vector to throw an assert in debug mode and no check was carried out at all in release mode. Since the method returns a boolean flag and I assume it's relatively infrequently called, the bounds checking is always carried out, and false is returned upon failure.

Some test code is below. It didn't seem to make sense to check in as a test, but it illustrates the operation:



```
#include "g2o/core/sparse_optimizer.h"
#include "g2o/types/sba/vertex_cam.h"

using namespace ::std;

int main()
{

  // Test code
  g2o::VertexCam* vc = new g2o::VertexCam();
  vc->setToOrigin();

  g2o::OptimizableGraph::Vertex* v = static_cast<g2o::OptimizableGraph::Vertex*> (vc);

  // These will and will automatically resize the eigen vector type
  Eigen::VectorXd test;
  bool success = v->getEstimateData(test);
  std::cout << success << ":" << test.transpose() << endl;
  success = v->getMinimalEstimateData(test);
  std::cout << success << ":" << test.transpose() << endl;

  // These will fail because the dimensions are incorrect
  Eigen::Vector3d fail;
  fail.setZero();
  success = v->getEstimateData(fail);
  std::cout << success << ":" << fail.transpose() << endl;
  success = v->getMinimalEstimateData(fail);
  std::cout << success << ":" << fail.transpose() << endl;

  // Now show that we can use eigen block operations
  Eigen::Matrix<double, 8, 1> bigTestVector8;
  bigTestVector8.setZero();
  Eigen::Matrix<double, 7, 1> bigTestVector7;
  bigTestVector8.setZero();

  auto block7 = bigTestVector7.head<7>();

  // This will fail (dimensions wrong)
  success = v->getEstimateData(block7);
  std::cout << success << ":" << bigTestVector8.transpose() << endl;

  // This will work
  success = v->getMinimalEstimateData(block7);
  std::cout << success << ":" << bigTestVector8.transpose() << endl;

  // Set from the data
  success = v->setEstimateData(bigTestVector8);
  std::cout << success << ":" << vc->estimate() << endl;

  // Set from data
  success = v->setMinimalEstimateData(block7);
  std::cout << success << ":" << vc->estimate() << endl;
  
}

```