### PR TITLE
Fix typo in examples/CMakeList.txt

### DIFF
--- a/g2o/examples/CMakeLists.txt
+++ b/g2o/examples/CMakeLists.txt
@@ -33,7 +33,7 @@ if (G2O_BUILD_SIM3_TYPES)
 endif()
 
 # slam 3d
-if (G2O_BUILD_SLAM3D_TyPES)
+if (G2O_BUILD_SLAM3D_TYPES)
   add_subdirectory(sphere)
 endif()
 


### PR DESCRIPTION
CMake was testing the value of `G2O_BUILD_SLAM3D_TyPES`, which was not present, which prevented the building of the `create_sphere` binary.