### PR TITLE
Fix incorrect jacobian for edge_se3_xyz_prior and add unit test for it

### DIFF
--- a/g2o/types/slam3d/edge_se3_xyzprior.cpp
+++ b/g2o/types/slam3d/edge_se3_xyzprior.cpp
@@ -65,7 +65,9 @@ namespace g2o {
   }
 
   void EdgeSE3XYZPrior::linearizeOplus() {
-    _jacobianOplusXi << Matrix3::Identity();
+    const VertexSE3* v = static_cast<const VertexSE3*>(_vertices[0]);
+    _jacobianOplusXi.block<3, 3>(0, 0) = v->estimate().rotation();
+    _jacobianOplusXi.block<3, 3>(0, 3) = Eigen::Matrix3d::Zero();
   }
 
   bool EdgeSE3XYZPrior::setMeasurementFromState() {

--- a/unit_test/gtest/CMakeLists.txt.in
+++ b/unit_test/gtest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/unit_test/slam3d/jacobians_slam3d.cpp
+++ b/unit_test/slam3d/jacobians_slam3d.cpp
@@ -33,6 +33,7 @@
 #include "g2o/types/slam3d/edge_se3.h"
 #include "g2o/types/slam3d/edge_pointxyz.h"
 #include "g2o/types/slam3d/edge_se3_pointxyz.h"
+#include "g2o/types/slam3d/edge_se3_xyzprior.h"
 #include "g2o/types/slam3d/dquat2mat.h"
 
 
@@ -72,6 +73,34 @@ TEST(Slam3D, EdgeSE3Jacobian)
     e.setMeasurement(internal::randomIsometry3());
 
     evaluateJacobian(e, jacobianWorkspace, numericJacobianWorkspace);
+  }
+}
+
+TEST(Slam3D, EdgeSE3XYZPriorJacobian)
+{
+  VertexSE3 v1;
+  v1.setId(0);
+
+  EdgeSE3XYZPrior e;
+  e.setVertex(0, &v1);
+  e.setInformation(EdgeSE3XYZPrior::InformationType::Identity());
+
+  JacobianWorkspace jacobianWorkspace;
+  JacobianWorkspace numericJacobianWorkspace;
+  numericJacobianWorkspace.updateSize(&e);
+  numericJacobianWorkspace.allocate();
+
+  // test in identity pose
+  v1.setEstimate(Eigen::Isometry3d::Identity());
+  e.setMeasurement(Eigen::Vector3d::Random());
+  evaluateJacobianUnary(e, jacobianWorkspace, numericJacobianWorkspace);
+
+  // test in random pose
+  for (int k = 0; k < 10000; ++k) {
+    v1.setEstimate(internal::randomIsometry3());
+    e.setMeasurement(Eigen::Vector3d::Random());
+
+    evaluateJacobianUnary(e, jacobianWorkspace, numericJacobianWorkspace);
   }
 }
 


### PR DESCRIPTION
Added unit tests for `EdgeSE3XYZPrior` to show current implementation of `EdgeSE3XYZPrior::linearizeOplus()` is incorrect. Since `VertexSE3` is updated in the local frame (right multiply with increment), its rotation should be taken into account. I was trying to introduce a GPS edge but it didn't work well and found this discussion in gtsam: [Jacobian for a translation component of Pose3 (e.g PartialPriorFactor)](https://groups.google.com/g/gtsam-users/c/jiiYCer8nUY), which could be a reference.

Haven't contributed to g2o before so apologies if I'm missing part of the workflow. 