### PR TITLE
fix QUAT type registration after clang-format

### DIFF
--- a/g2o/examples/interactive_slam/g2o_interactive/types_online.cpp
+++ b/g2o/examples/interactive_slam/g2o_interactive/types_online.cpp
@@ -35,7 +35,10 @@ G2O_REGISTER_TYPE_GROUP(online);
 G2O_REGISTER_TYPE(ONLINE_EDGE_SE2, OnlineEdgeSE2);
 G2O_REGISTER_TYPE(ONLINE_VERTEX_SE2, OnlineVertexSE2);
 
-G2O_REGISTER_TYPE(ONLINE_VERTEX_SE3 : QUAT, OnlineVertexSE3);
-G2O_REGISTER_TYPE(ONLINE_EDGE_SE3 : QUAT, OnlineEdgeSE3);
+// clang-format off
+// otherwise it will result in non-working "ONLINE_VERTEX_SE3 : QUAT"
+G2O_REGISTER_TYPE(ONLINE_VERTEX_SE3:QUAT, OnlineVertexSE3);
+G2O_REGISTER_TYPE(ONLINE_EDGE_SE3:QUAT, OnlineEdgeSE3);
+// clang-format on
 
 }  // namespace g2o

--- a/g2o/types/slam3d/types_slam3d.cpp
+++ b/g2o/types/slam3d/types_slam3d.cpp
@@ -35,8 +35,11 @@ namespace g2o {
 
 G2O_REGISTER_TYPE_GROUP(slam3d);
 
-G2O_REGISTER_TYPE(VERTEX_SE3 : QUAT, VertexSE3);
-G2O_REGISTER_TYPE(EDGE_SE3 : QUAT, EdgeSE3);
+// clang-format off
+// otherwise it will result in non-working "VERTEX_SE3 : QUAT"
+G2O_REGISTER_TYPE(VERTEX_SE3:QUAT, VertexSE3);
+G2O_REGISTER_TYPE(EDGE_SE3:QUAT, EdgeSE3);
+// clang-format on
 G2O_REGISTER_TYPE(VERTEX_TRACKXYZ, VertexPointXYZ);
 
 G2O_REGISTER_TYPE(PARAMS_SE3OFFSET, ParameterSE3Offset);


### PR DESCRIPTION
The types with a colon and QUAT did not work for me. I think the problem is that clang-format changed the originally intended `VERTEX_SE3:QUAT` to `VERTEX_SE3 : QUAT`. This is reverted by this PR and it should not occur in the future anymore due to the temporary deactivation of clang-format.