### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ On Windows with `vcpkg` the following two commands will generate build scripts f
 -   `cmake -G "Visual Studio 14 2017 Win64" -DG2O_BUILD_APPS=ON -DG2O_BUILD_EXAMPLES=ON -DVCPKG_TARGET_TRIPLET="%VCPKG_DEFAULT_TRIPLET%" -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT_DIR%\scripts\buildsystems\vcpkg.cmake" ..`
 
 If you are compiling on Windows and you are for some reasons **not** using `vcpkg` please download Eigen3 and extract it.
-Within cmake-gui set the variable G2O_EIGEN3_INCLUDE to that directory.
+Within cmake-gui set the variable EIGEN3_INCLUDE_DIR to that directory.
+
+-   `mkdir build`
+-   `cd build`
+-   `cmake .. -G "Visual Studio 15 2017 Win64" -DG2O_BUILD_APPS=ON -DG2O_BUILD_EXAMPLES=ON -DEIGEN3_INCLUDE_DIR="<THE_PATH_WHERE_YOU_PLACED_EIGEN3_AND_THE_EIGEN3_CMakeLists.txt>"
 
 ## Cross-Compiling for Android
 


### PR DESCRIPTION
The variable G2O_EIGEN3_INCLUDE is no longer existing. The current variable should be EIGEN3_INCLUDE_DIR. Corrected the documentation. Also added and example that was verified by a trying to build without vcpkg under windows 10 and Visual Studio 15 2017. Please note: I only tried it on one machine.