### PR TITLE
Install find-macro for SuiteSparse.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,10 @@ install(
     NAMESPACE "${G2O_NAMESPACE}"
     DESTINATION "${G2O_CONFIG_INSTALL_DIR}")
 
+install(
+    FILES "${g2o_SOURCE_DIR}/cmake_modules/FindSuiteSparse.cmake"
+    DESTINATION "${G2O_CONFIG_INSTALL_DIR}/modules")
+
 # building unit test framework and our tests
 option(BUILD_UNITTESTS "build unit test framework and the tests" OFF)
 if(BUILD_UNITTESTS)

--- a/cmake_modules/Config.cmake.in
+++ b/cmake_modules/Config.cmake.in
@@ -1,7 +1,10 @@
 include(CMakeFindDependencyMacro)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)
+
 find_dependency(Eigen3)
 find_dependency(OpenGL)
+find_dependency(SuiteSparse)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@G2O_TARGETS_EXPORT_NAME@.cmake")
 


### PR DESCRIPTION
When linking publicly against a self defined target, you need to make sure that dependent projects can find it as well.

I believe even better would be to hide Cholmod inside the implementation of g2o::LinearSolverCholmod to allow for private linking of SuiteSparse, but this would need some more effort to implement.