### PR TITLE
Revert "Install find-macro for SuiteSparse. (#618)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,10 +526,6 @@ install(
     NAMESPACE "${G2O_NAMESPACE}"
     DESTINATION "${G2O_CONFIG_INSTALL_DIR}")
 
-install(
-    FILES "${g2o_SOURCE_DIR}/cmake_modules/FindSuiteSparse.cmake"
-    DESTINATION "${G2O_CONFIG_INSTALL_DIR}/modules")
-
 # building unit test framework and our tests
 option(BUILD_UNITTESTS "build unit test framework and the tests" OFF)
 if(BUILD_UNITTESTS)

--- a/cmake_modules/Config.cmake.in
+++ b/cmake_modules/Config.cmake.in
@@ -1,10 +1,7 @@
 include(CMakeFindDependencyMacro)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)
-
 find_dependency(Eigen3)
 find_dependency(OpenGL)
-find_dependency(SuiteSparse)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@G2O_TARGETS_EXPORT_NAME@.cmake")
 


### PR DESCRIPTION
This reverts commit bd9c912de45081157078859482cecdd73855d3c1.

It's not necessary anymore since Cholmod is now linked privatly.