### PR TITLE
Fix #626: g2opy install target at .

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,3 +63,4 @@ target_link_libraries(g2opy PRIVATE
     types_slam3d_addons
 )
 target_include_directories(g2opy PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+install(TARGETS g2opy LIBRARY DESTINATION g2opy)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,4 +63,4 @@ target_link_libraries(g2opy PRIVATE
     types_slam3d_addons
 )
 target_include_directories(g2opy PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-install(TARGETS g2opy LIBRARY DESTINATION g2opy)
+install(TARGETS g2opy LIBRARY DESTINATION .)


### PR DESCRIPTION
In order to just `import g2o` the pybind11 target needs to be installed at `.`.