### PR TITLE
Fix memory leak in SparseOptimizer::setAlgorithm

### DIFF
--- a/g2o/core/sparse_optimizer.cpp
+++ b/g2o/core/sparse_optimizer.cpp
@@ -560,8 +560,12 @@ void SparseOptimizer::discardTop(SparseOptimizer::VertexContainer& vlist) {
 void SparseOptimizer::setVerbose(bool verbose) { _verbose = verbose; }
 
 void SparseOptimizer::setAlgorithm(OptimizationAlgorithm* algorithm) {
-  if (_algorithm)  // reset the optimizer for the formerly used solver
+  if (_algorithm) {
+    // reset the optimizer for the formerly used solver in case release() won't
+    // delete it
     _algorithm->setOptimizer(nullptr);
+    release(_algorithm);
+  }
 
   _algorithm = algorithm;
 


### PR DESCRIPTION
Adds `release()` call on the formerly used solver into `SparseOptimizer::setAlgorithm`.

Closes #631.