### PR TITLE
Add missing `#include <cassert>` directives

### DIFF
--- a/g2o/apps/g2o_simulator/sensor_line3d.cpp
+++ b/g2o/apps/g2o_simulator/sensor_line3d.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_line3d.h"
 
+#include <cassert>
+
 namespace g2o {
 using namespace std;
 

--- a/g2o/apps/g2o_simulator/sensor_pointxy.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxy.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxy.h"
 
+#include <cassert>
+
 using namespace Eigen;
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_pointxy_bearing.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxy_bearing.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxy_bearing.h"
 
+#include <cassert>
+
 using namespace Eigen;
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_pointxy_offset.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxy_offset.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxy_offset.h"
 
+#include <cassert>
+
 #include "g2o/core/factory.h"
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_pointxyz.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxyz.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxyz.h"
 
+#include <cassert>
+
 namespace g2o {
 using namespace std;
 using namespace Eigen;

--- a/g2o/apps/g2o_simulator/sensor_pointxyz_depth.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxyz_depth.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxyz_depth.h"
 
+#include <cassert>
+
 namespace g2o {
 using namespace std;
 using namespace Eigen;

--- a/g2o/apps/g2o_simulator/sensor_pointxyz_disparity.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pointxyz_disparity.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pointxyz_disparity.h"
 
+#include <cassert>
+
 namespace g2o {
 using namespace std;
 using namespace Eigen;

--- a/g2o/apps/g2o_simulator/sensor_pose2d.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pose2d.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pose2d.h"
 
+#include <cassert>
+
 using namespace Eigen;
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_pose3d.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pose3d.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pose3d.h"
 
+#include <cassert>
+
 #include "g2o/types/slam3d/isometry3d_mappings.h"
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_pose3d_offset.cpp
+++ b/g2o/apps/g2o_simulator/sensor_pose3d_offset.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_pose3d_offset.h"
 
+#include <cassert>
+
 #include "g2o/types/slam3d/isometry3d_mappings.h"
 
 namespace g2o {

--- a/g2o/apps/g2o_simulator/sensor_se3_prior.cpp
+++ b/g2o/apps/g2o_simulator/sensor_se3_prior.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_se3_prior.h"
 
+#include <cassert>
+
 namespace g2o {
 using namespace std;
 

--- a/g2o/apps/g2o_simulator/sensor_segment2d.cpp
+++ b/g2o/apps/g2o_simulator/sensor_segment2d.cpp
@@ -26,6 +26,7 @@
 
 #include "sensor_segment2d.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "g2o/apps/g2o_simulator/simutils.h"

--- a/g2o/apps/g2o_simulator/sensor_segment2d_line.cpp
+++ b/g2o/apps/g2o_simulator/sensor_segment2d_line.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_segment2d_line.h"
 
+#include <cassert>
+
 #include "g2o/apps/g2o_simulator/simutils.h"
 using namespace std;
 using namespace Eigen;

--- a/g2o/apps/g2o_simulator/sensor_segment2d_pointline.cpp
+++ b/g2o/apps/g2o_simulator/sensor_segment2d_pointline.cpp
@@ -26,6 +26,8 @@
 
 #include "sensor_segment2d_pointline.h"
 
+#include <cassert>
+
 #include "g2o/apps/g2o_simulator/simutils.h"
 using namespace std;
 using namespace Eigen;

--- a/g2o/apps/g2o_simulator/simulator.cpp
+++ b/g2o/apps/g2o_simulator/simulator.cpp
@@ -26,6 +26,7 @@
 
 #include "simulator.h"
 
+#include <cassert>
 #include <iostream>
 namespace g2o {
 using namespace std;

--- a/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
+++ b/g2o/apps/g2o_viewer/g2o_qglviewer.cpp
@@ -18,6 +18,8 @@
 
 #include "g2o_qglviewer.h"
 
+#include <cassert>
+
 #include "g2o/core/hyper_graph_action.h"
 #include "g2o/core/sparse_optimizer.h"
 #include "g2o/stuff/opengl_primitives.h"

--- a/g2o/core/base_dynamic_vertex.h
+++ b/g2o/core/base_dynamic_vertex.h
@@ -27,6 +27,8 @@
 #ifndef G2O_BASE_DYNAMIC_VERTEX_H
 #define G2O_BASE_DYNAMIC_VERTEX_H
 
+#include <cassert>
+
 #include "base_vertex.h"
 
 namespace g2o {

--- a/g2o/core/base_fixed_sized_edge.hpp
+++ b/g2o/core/base_fixed_sized_edge.hpp
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
+
 template <int D, typename E, typename... VertexTypes>
 void BaseFixedSizedEdge<D, E, VertexTypes...>::resize(size_t size) {
   assert(size == _nr_of_vertices &&

--- a/g2o/core/base_variable_sized_edge.hpp
+++ b/g2o/core/base_variable_sized_edge.hpp
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
+
 namespace internal {
 inline int computeUpperTriangleIndex(int i, int j) {
   int elemsUpToCol = ((j - 1) * j) / 2;

--- a/g2o/core/base_vertex.h
+++ b/g2o/core/base_vertex.h
@@ -31,6 +31,7 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <stack>
+#include <cassert>
 
 #include "creators.h"
 #include "g2o/stuff/macros.h"

--- a/g2o/core/block_solver.hpp
+++ b/g2o/core/block_solver.hpp
@@ -27,6 +27,7 @@
 #include <Eigen/LU>
 #include <fstream>
 #include <iomanip>
+#include <cassert>
 
 #include "g2o/stuff/macros.h"
 #include "g2o/stuff/misc.h"

--- a/g2o/core/hyper_dijkstra.cpp
+++ b/g2o/core/hyper_dijkstra.cpp
@@ -26,8 +26,7 @@
 
 #include "hyper_dijkstra.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <deque>
 #include <iostream>
 #include <queue>

--- a/g2o/core/jacobian_workspace.cpp
+++ b/g2o/core/jacobian_workspace.cpp
@@ -26,6 +26,7 @@
 
 #include "jacobian_workspace.h"
 
+#include <cassert>
 #include <cmath>
 
 #include "optimizable_graph.h"

--- a/g2o/core/linear_solver.h
+++ b/g2o/core/linear_solver.h
@@ -27,6 +27,7 @@
 #ifndef G2O_LINEAR_SOLVER_H
 #define G2O_LINEAR_SOLVER_H
 
+#include <cassert>
 #include <functional>
 
 #include "g2o/core/marginal_covariance_cholesky.h"

--- a/g2o/core/optimization_algorithm_dogleg.cpp
+++ b/g2o/core/optimization_algorithm_dogleg.cpp
@@ -26,6 +26,7 @@
 
 #include "optimization_algorithm_dogleg.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "batch_stats.h"

--- a/g2o/core/optimization_algorithm_gauss_newton.cpp
+++ b/g2o/core/optimization_algorithm_gauss_newton.cpp
@@ -26,6 +26,7 @@
 
 #include "optimization_algorithm_gauss_newton.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "batch_stats.h"

--- a/g2o/core/optimization_algorithm_levenberg.cpp
+++ b/g2o/core/optimization_algorithm_levenberg.cpp
@@ -26,6 +26,7 @@
 
 #include "optimization_algorithm_levenberg.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "batch_stats.h"

--- a/g2o/core/optimization_algorithm_with_hessian.cpp
+++ b/g2o/core/optimization_algorithm_with_hessian.cpp
@@ -26,6 +26,7 @@
 
 #include "optimization_algorithm_with_hessian.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "optimizable_graph.h"

--- a/g2o/core/parameter_container.cpp
+++ b/g2o/core/parameter_container.cpp
@@ -26,6 +26,7 @@
 
 #include "parameter_container.h"
 
+#include <cassert>
 #include <iostream>
 
 #include "factory.h"

--- a/g2o/core/sparse_block_matrix.hpp
+++ b/g2o/core/sparse_block_matrix.hpp
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
+
 namespace g2o {
 
 template <class MatrixType>

--- a/g2o/core/sparse_optimizer_terminate_action.cpp
+++ b/g2o/core/sparse_optimizer_terminate_action.cpp
@@ -26,6 +26,7 @@
 
 #include "sparse_optimizer_terminate_action.h"
 
+#include <cassert>
 #include <limits>
 
 #include "sparse_optimizer.h"

--- a/g2o/examples/ba/ba_demo.cpp
+++ b/g2o/examples/ba/ba_demo.cpp
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 
+#include <cassert>
 #include <iostream>
 #include <unordered_set>
 

--- a/g2o/examples/ba_anchored_inverse_depth/ba_anchored_inverse_depth_demo.cpp
+++ b/g2o/examples/ba_anchored_inverse_depth/ba_anchored_inverse_depth_demo.cpp
@@ -24,8 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <stdint.h>
-
+#include <cstdint>
+#include <cassert>
 #include <iostream>
 #include <unordered_set>
 

--- a/g2o/examples/bal/bal_example.cpp
+++ b/g2o/examples/bal/bal_example.cpp
@@ -27,6 +27,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <iostream>
+#include <cassert>
 
 #ifdef G2O_USE_VENDORED_CERES
 #include "g2o/EXTERNAL/ceres/autodiff.h"

--- a/g2o/examples/calibration_odom_laser/gm2dl_io.cpp
+++ b/g2o/examples/calibration_odom_laser/gm2dl_io.cpp
@@ -28,6 +28,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <cassert>
 
 #include "g2o/core/factory.h"
 #include "g2o/core/sparse_optimizer.h"

--- a/g2o/examples/calibration_odom_laser/sclam_odom_laser.cpp
+++ b/g2o/examples/calibration_odom_laser/sclam_odom_laser.cpp
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
 #include <csignal>
 #include <fstream>
 #include <iostream>

--- a/g2o/examples/calibration_odom_laser/sclam_pure_calibration.cpp
+++ b/g2o/examples/calibration_odom_laser/sclam_pure_calibration.cpp
@@ -24,6 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
 #include <csignal>
 #include <fstream>
 #include <iostream>

--- a/g2o/examples/convert_segment_line/convertSegmentLine.cpp
+++ b/g2o/examples/convert_segment_line/convertSegmentLine.cpp
@@ -24,8 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <signal.h>
-
+#include <csignal>
 #include <algorithm>
 #include <cassert>
 #include <fstream>

--- a/g2o/examples/data_convert/convert_sba_slam3d.cpp
+++ b/g2o/examples/data_convert/convert_sba_slam3d.cpp
@@ -26,6 +26,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <cassert>
 
 #include "g2o/core/optimizable_graph.h"
 #include "g2o/stuff/command_args.h"

--- a/g2o/examples/g2o_hierarchical/edge_creator.cpp
+++ b/g2o/examples/g2o_hierarchical/edge_creator.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_creator.h"
 
+#include <cassert>
+
 #include "g2o/core/factory.h"
 
 namespace g2o {

--- a/g2o/examples/g2o_hierarchical/edge_labeler.cpp
+++ b/g2o/examples/g2o_hierarchical/edge_labeler.cpp
@@ -27,6 +27,7 @@
 #include "edge_labeler.h"
 
 #include <Eigen/Dense>
+#include <cassert>
 
 #include "g2o/stuff/unscented.h"
 

--- a/g2o/examples/g2o_hierarchical/simple_star_ops.cpp
+++ b/g2o/examples/g2o_hierarchical/simple_star_ops.cpp
@@ -30,6 +30,7 @@
 #include <Eigen/Eigenvalues>
 #include <Eigen/LU>
 #include <iostream>
+#include <cassert>
 
 #include "backbone_tree_action.h"
 #include "edge_types_cost_function.h"

--- a/g2o/examples/g2o_unfold/g2o-unfold.cpp
+++ b/g2o/examples/g2o_unfold/g2o-unfold.cpp
@@ -27,8 +27,8 @@
 //  ../aisnavigation-free/bin/g2o-unfold -i 30 -solver var_cholmod -v -gnudump
 //  vic.dat ../datasets/2D/victoriaPark/victoriaPark.g2o
 
-#include <signal.h>
-
+#include <cassert>
+#include <csignal>
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/g2o/examples/interactive_slam/g2o_incremental/graph_optimizer_sparse_incremental.cpp
+++ b/g2o/examples/interactive_slam/g2o_incremental/graph_optimizer_sparse_incremental.cpp
@@ -16,6 +16,8 @@
 
 #include "graph_optimizer_sparse_incremental.h"
 
+#include <cassert>
+
 #include "g2o/core/block_solver.h"
 #include "g2o/core/optimization_algorithm_gauss_newton.h"
 #include "g2o/examples/interactive_slam/g2o_interactive/types_slam2d_online.h"

--- a/g2o/examples/interactive_slam/g2o_incremental/linear_solver_cholmod_online.h
+++ b/g2o/examples/interactive_slam/g2o_incremental/linear_solver_cholmod_online.h
@@ -19,6 +19,7 @@
 
 #include <camd.h>
 #include <cholmod.h>
+#include <cassert>
 
 #include "g2o/core/batch_stats.h"
 #include "g2o/core/linear_solver.h"

--- a/g2o/examples/interactive_slam/g2o_interactive/fast_output.h
+++ b/g2o/examples/interactive_slam/g2o_interactive/fast_output.h
@@ -37,9 +37,8 @@
 #ifndef G2O_FAST_OUTPUT_H
 #define G2O_FAST_OUTPUT_H
 
-#include <assert.h>
-#include <stdint.h>
-
+#include <cassert>
+#include <cstdint>
 #include <cstdio>
 
 #ifdef __cplusplus

--- a/g2o/examples/interactive_slam/g2o_interactive/g2o_slam_interface.cpp
+++ b/g2o/examples/interactive_slam/g2o_interactive/g2o_slam_interface.cpp
@@ -27,6 +27,7 @@
 #include "g2o_slam_interface.h"
 
 #include <iostream>
+#include <cassert>
 
 #include "fast_output.h"
 #include "g2o/types/slam3d/se3quat.h"

--- a/g2o/examples/interactive_slam/g2o_interactive/generate_commands.cpp
+++ b/g2o/examples/interactive_slam/g2o_interactive/generate_commands.cpp
@@ -24,8 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <signal.h>
-
+#include <cassert>
+#include <csignal>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>

--- a/g2o/examples/target/targetTypes6D.hpp
+++ b/g2o/examples/target/targetTypes6D.hpp
@@ -6,6 +6,7 @@
 #include <g2o/core/base_vertex.h>
 
 #include <Eigen/Core>
+#include <cassert>
 
 using namespace g2o;
 

--- a/g2o/examples/tutorial_slam2d/se2.h
+++ b/g2o/examples/tutorial_slam2d/se2.h
@@ -29,6 +29,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <cassert>
 
 #include "g2o/stuff/macros.h"
 #include "g2o/stuff/misc.h"

--- a/g2o/solvers/cholmod/linear_solver_cholmod.h
+++ b/g2o/solvers/cholmod/linear_solver_cholmod.h
@@ -27,6 +27,8 @@
 #ifndef G2O_LINEAR_SOLVER_CHOLMOD
 #define G2O_LINEAR_SOLVER_CHOLMOD
 
+#include <cassert>
+
 #include "cholmod_wrapper.h"
 #include "g2o/core/batch_stats.h"
 #include "g2o/core/linear_solver.h"

--- a/g2o/solvers/csparse/linear_solver_csparse.h
+++ b/g2o/solvers/csparse/linear_solver_csparse.h
@@ -28,6 +28,7 @@
 #define G2O_LINEAR_SOLVERCSPARSE_H
 
 #include <iostream>
+#include <cassert>
 
 #include "csparse_wrapper.h"
 #include "g2o/core/batch_stats.h"

--- a/g2o/solvers/dense/linear_solver_dense.h
+++ b/g2o/solvers/dense/linear_solver_dense.h
@@ -32,6 +32,7 @@
 #include <Eigen/Core>
 #include <utility>
 #include <vector>
+#include <cassert>
 
 #include "g2o/core/batch_stats.h"
 #include "g2o/core/linear_solver.h"

--- a/g2o/solvers/eigen/linear_solver_eigen.h
+++ b/g2o/solvers/eigen/linear_solver_eigen.h
@@ -31,6 +31,7 @@
 #include <Eigen/SparseCholesky>
 #include <iostream>
 #include <vector>
+#include <cassert>
 
 #include "g2o/core/batch_stats.h"
 #include "g2o/core/linear_solver.h"

--- a/g2o/solvers/pcg/linear_solver_pcg.hpp
+++ b/g2o/solvers/pcg/linear_solver_pcg.hpp
@@ -26,6 +26,8 @@
 
 // helpers for doing fixed or variable size operations on the matrices
 
+#include <cassert>
+
 namespace internal {
 
 #ifdef _MSC_VER

--- a/g2o/solvers/slam2d_linear/solver_slam2d_linear.cpp
+++ b/g2o/solvers/slam2d_linear/solver_slam2d_linear.cpp
@@ -27,6 +27,7 @@
 #include "solver_slam2d_linear.h"
 
 #include <Eigen/Core>
+#include <cassert>
 
 #include "g2o/core/hyper_dijkstra.h"
 #include "g2o/core/solver.h"

--- a/g2o/solvers/structure_only/structure_only_solver.h
+++ b/g2o/solvers/structure_only/structure_only_solver.h
@@ -28,6 +28,8 @@
 #ifndef G2O_STRUCTURE_ONLY_SOLVER_H
 #define G2O_STRUCTURE_ONLY_SOLVER_H
 
+#include <cassert>
+
 #include "g2o/core/base_binary_edge.h"
 #include "g2o/core/base_vertex.h"
 #include "g2o/core/optimization_algorithm.h"

--- a/g2o/stuff/unscented.h
+++ b/g2o/stuff/unscented.h
@@ -29,6 +29,7 @@
 
 #include <Eigen/Cholesky>
 #include <Eigen/Core>
+#include <cassert>
 
 namespace g2o {
 

--- a/g2o/types/sim3/sim3.h
+++ b/g2o/types/sim3/sim3.h
@@ -28,6 +28,7 @@
 #define G2O_SIM_3
 
 #include <Eigen/Geometry>
+#include <cassert>
 
 #include "g2o/stuff/misc.h"
 #include "g2o/types/slam3d/se3_ops.h"

--- a/g2o/types/slam2d/edge_se2_lotsofxy.cpp
+++ b/g2o/types/slam2d/edge_se2_lotsofxy.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_lotsofxy.h"
 
+#include <cassert>
+
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"
 #include "g2o/stuff/opengl_wrapper.h"

--- a/g2o/types/slam2d/edge_se2_offset.cpp
+++ b/g2o/types/slam2d/edge_se2_offset.cpp
@@ -27,6 +27,7 @@
 #include "edge_se2_offset.h"
 
 #include <iostream>
+#include <cassert>
 
 #include "parameter_se2_offset.h"
 

--- a/g2o/types/slam2d/edge_se2_pointxy.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_pointxy.h"
 
+#include <cassert>
+
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"
 #include "g2o/stuff/opengl_wrapper.h"

--- a/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_pointxy_bearing.h"
 
+#include <cassert>
+
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"
 #include "g2o/stuff/opengl_wrapper.h"

--- a/g2o/types/slam2d/edge_se2_pointxy_calib.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_calib.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_pointxy_calib.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE2PointXYCalib::EdgeSE2PointXYCalib()

--- a/g2o/types/slam2d/edge_se2_pointxy_offset.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_offset.cpp
@@ -27,6 +27,7 @@
 #include "edge_se2_pointxy_offset.h"
 
 #include <iostream>
+#include <cassert>
 
 #include "parameter_se2_offset.h"
 

--- a/g2o/types/slam2d/edge_se2_prior.cpp
+++ b/g2o/types/slam2d/edge_se2_prior.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_prior.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE2Prior::EdgeSE2Prior() : BaseUnaryEdge<3, SE2, VertexSE2>() {}

--- a/g2o/types/slam2d/edge_se2_twopointsxy.cpp
+++ b/g2o/types/slam2d/edge_se2_twopointsxy.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_twopointsxy.h"
 
+#include <cassert>
+
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"
 #include "g2o/stuff/opengl_wrapper.h"

--- a/g2o/types/slam2d/se2.h
+++ b/g2o/types/slam2d/se2.h
@@ -29,6 +29,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <cassert>
 
 #include "g2o/core/eigen_types.h"
 #include "g2o/stuff/misc.h"

--- a/g2o/types/slam2d_addons/edge_se2_line2d.cpp
+++ b/g2o/types/slam2d_addons/edge_se2_line2d.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_line2d.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE2Line2D::EdgeSE2Line2D()

--- a/g2o/types/slam2d_addons/edge_se2_segment2d.cpp
+++ b/g2o/types/slam2d_addons/edge_se2_segment2d.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se2_segment2d.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE2Segment2D::EdgeSE2Segment2D()

--- a/g2o/types/slam3d/edge_se3_lotsofxyz.cpp
+++ b/g2o/types/slam3d/edge_se3_lotsofxyz.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se3_lotsofxyz.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE3LotsOfXYZ::EdgeSE3LotsOfXYZ()

--- a/g2o/types/slam3d/edge_se3_offset.cpp
+++ b/g2o/types/slam3d/edge_se3_offset.cpp
@@ -27,6 +27,7 @@
 #include "edge_se3_offset.h"
 
 #include <iostream>
+#include <cassert>
 
 #include "isometry3d_gradients.h"
 #include "parameter_se3_offset.h"

--- a/g2o/types/slam3d/edge_se3_pointxyz.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include <iostream>
+#include <cassert>
 
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"

--- a/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se3_pointxyz_depth.h"
 
+#include <cassert>
+
 namespace g2o {
 
 // point to camera projection, monocular

--- a/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
@@ -28,6 +28,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <cassert>
 
 #ifdef G2O_HAVE_OPENGL
 #include "g2o/stuff/opengl_primitives.h"

--- a/g2o/types/slam3d/edge_se3_prior.cpp
+++ b/g2o/types/slam3d/edge_se3_prior.cpp
@@ -27,6 +27,7 @@
 #include "edge_se3_prior.h"
 
 #include <iostream>
+#include <cassert>
 
 #include "isometry3d_gradients.h"
 

--- a/g2o/types/slam3d/edge_se3_xyzprior.cpp
+++ b/g2o/types/slam3d/edge_se3_xyzprior.cpp
@@ -26,6 +26,8 @@
 
 #include "edge_se3_xyzprior.h"
 
+#include <cassert>
+
 namespace g2o {
 
 EdgeSE3XYZPrior::EdgeSE3XYZPrior()

--- a/g2o/types/slam3d/se3quat.h
+++ b/g2o/types/slam3d/se3quat.h
@@ -29,6 +29,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <cassert>
 
 #include "g2o/stuff/misc.h"
 #include "se3_ops.h"


### PR DESCRIPTION
When I tried to do a release build of my project that uses g2o and Eigen from their most recent master commits, I got several `error: ‘assert’ was not declared in this scope` errors in g2o's code. I don't encounter these errors with older Eigen versions (I've been using a December 2022 commit until now), but it seems strange that g2o is influenced by Eigen in such a way.

Anyway, in this PR I added the missing `#include <cassert>` directives in every file that uses `assert(...)` and it fixed my issue. I also replaced several occurrences of `#include <some_std_header.h>`-style includes with `#include <csome_std_header>` (e.g. `<signal.h>` got replaced with `<csignal>`) that I encountered along the way.