### PR TITLE
LM fix memory bug

### DIFF
--- a/g2o/core/optimization_algorithm_levenberg.cpp
+++ b/g2o/core/optimization_algorithm_levenberg.cpp
@@ -122,11 +122,10 @@ OptimizationAlgorithm::SolverResult OptimizationAlgorithmLevenberg::solve(
     if (!ok2) tempChi = std::numeric_limits<double>::max();
 
     rho = (currentChi - tempChi);
-    double scale = computeScale();
-    scale += cst(1e-3);  // make sure it's non-zero :)
+    double scale = ok2 ? computeScale() + cst(1e-3) : 1; // make sure it's non-zero :)
     rho /= scale;
 
-    if (rho > 0 && g2o_isfinite(tempChi)) {  // last step was good
+    if (rho > 0 && g2o_isfinite(tempChi) && ok2) {  // last step was good
       double alpha = 1. - pow((2 * rho - 1), 3);
       // crop lambda between minimum and maximum factors
       alpha = (std::min)(alpha, _goodStepUpperScale);


### PR DESCRIPTION
This PR fixes a non-deterministic behaviour of the Levenberg Marquardt algorithm.

Description of the bug that this PR fixes:
After a "cholesky failure", the solver doesn't fill in the parameter increment, i. e. the `_solver.x()` contains a garbage. Then the `computeScale` method uses the `_solver.x()` with the garbage to compute the `scale`, finally this leads to accepting an update with the garbage values and, hence, the non-deterministic behaviour.