### PR TITLE
Drop CXX_STANDARD on g2o_ceres_ad INTERFACE lib

### DIFF
--- a/g2o/autodiff/CMakeLists.txt
+++ b/g2o/autodiff/CMakeLists.txt
@@ -1,7 +1,4 @@
 add_library(g2o_ceres_ad INTERFACE)
-set_target_properties(g2o_ceres_ad PROPERTIES
-    CXX_STANDARD 17
-)
 
 install(TARGETS g2o_ceres_ad
   EXPORT ${G2O_TARGETS_EXPORT_NAME}


### PR DESCRIPTION
fix #666