### PR TITLE
Some refactoring fixed sized edge cpp17

### DIFF
--- a/g2o/core/auto_differentiation.h
+++ b/g2o/core/auto_differentiation.h
@@ -201,8 +201,7 @@ class AutoDifferentiation {
         "Dynamically sized vertices are not supported");
     // all vertices are fixed, no need to compute anything here
     if (that->allVerticesFixed()) {
-      int unused[] = {(that->template jacobianOplusXn<Ints>().setZero(), 0)...};
-      (void)unused;
+      (void(that->template jacobianOplusXn<Ints>().setZero()), ...);
       return;
     }
 
@@ -236,18 +235,16 @@ class AutoDifferentiation {
 
     assert(diffState && "Error during Automatic Differentiation");
     if (!diffState) {  // something went wrong during AD
-      int unused[] = {(std::get<Ints>(ad_jacobians).setZero(), 0)...};
-      (void)unused;
+      (void(std::get<Ints>(ad_jacobians).setZero()), ...);
       return;
     }
     // copy over the Jacobians (convert row-major -> column-major) for non-fixed
     // vertices
-    int unused[] = {that->template vertexXn<Ints>()->fixed()
-                        ? (that->template jacobianOplusXn<Ints>().setZero(), 0)
-                        : (assign(that->template jacobianOplusXn<Ints>(),
-                                  std::get<Ints>(ad_jacobians)),
-                           0)...};
-    (void)unused;
+    (void(that->template vertexXn<Ints>()->fixed()
+              ? (that->template jacobianOplusXn<Ints>().setZero(), 0)
+              : (assign(that->template jacobianOplusXn<Ints>(),
+                        std::get<Ints>(ad_jacobians)), 0)),
+          ...);
   }
 
   //! helper function to perform a = b

--- a/g2o/core/base_fixed_sized_edge.hpp
+++ b/g2o/core/base_fixed_sized_edge.hpp
@@ -37,9 +37,7 @@ template <int D, typename E, typename... VertexTypes>
 template <std::size_t... Ints>
 bool BaseFixedSizedEdge<D, E, VertexTypes...>::allVerticesFixedNs(
     std::index_sequence<Ints...>) const {
-  bool fixed[] = {vertexXn<Ints>()->fixed()...};
-  return std::all_of(std::begin(fixed), std::end(fixed),
-                     [](bool value) { return value; });
+  return ( ... && vertexXn<Ints>()->fixed());
 }
 
 template <int D, typename E, typename... VertexTypes>

--- a/g2o/core/base_fixed_sized_edge.hpp
+++ b/g2o/core/base_fixed_sized_edge.hpp
@@ -69,8 +69,7 @@ template <std::size_t... Ints>
 void BaseFixedSizedEdge<D, E, VertexTypes...>::constructQuadraticFormNs(
     const InformationType& omega, const ErrorVector& weightedError,
     std::index_sequence<Ints...>) {
-  int unused[] = {(constructQuadraticFormN<Ints>(omega, weightedError), 0)...};
-  (void)unused;
+  (void(constructQuadraticFormN<Ints>(omega, weightedError)), ...);
 }
 
 // overloading constructOffDiagonalQuadraticFormMs to
@@ -86,9 +85,7 @@ template <int N, std::size_t... Ints, typename AtOType>
 void BaseFixedSizedEdge<D, E, VertexTypes...>::
     constructOffDiagonalQuadraticFormMs(const AtOType& AtO,
                                         std::index_sequence<Ints...>) {
-  int unused[] = {
-      (constructOffDiagonalQuadraticFormM<N, Ints, AtOType>(AtO), 0)...};
-  (void)unused;
+  (void(constructOffDiagonalQuadraticFormM<N, Ints, AtOType>(AtO)), ...);
 }
 
 template <int D, typename E, typename... VertexTypes>
@@ -146,15 +143,12 @@ template <int D, typename E, typename... VertexTypes>
 template <std::size_t... Ints>
 void BaseFixedSizedEdge<D, E, VertexTypes...>::linearizeOplus_allocate(
     JacobianWorkspace& jacobianWorkspace, std::index_sequence<Ints...>) {
-  int unused[] = {
-      (new (&std::get<Ints>(_jacobianOplus))
-           JacobianType<D, VertexDimension<Ints>()>(
-               jacobianWorkspace.workspaceForVertex(Ints),
-               D < 0 ? _dimension : D,
-               VertexDimension<Ints>() < 0 ? vertexXn<Ints>()->dimension()
-                                           : VertexDimension<Ints>()),
-       0)...};
-  (void)unused;
+  (new (&std::get<Ints>(_jacobianOplus))
+       JacobianType<D, VertexDimension<Ints>()>(
+           jacobianWorkspace.workspaceForVertex(Ints), D < 0 ? _dimension : D,
+           VertexDimension<Ints>() < 0 ? vertexXn<Ints>()->dimension()
+                                       : VertexDimension<Ints>()),
+   ...);
 }
 
 template <int D, typename E, typename... VertexTypes>
@@ -205,8 +199,7 @@ template <int D, typename E, typename... VertexTypes>
 template <std::size_t... Ints>
 void BaseFixedSizedEdge<D, E, VertexTypes...>::linearizeOplusNs(
     std::index_sequence<Ints...>) {
-  int unused[] = {(linearizeOplusN<Ints>(), 0)...};
-  (void)unused;
+  (void(linearizeOplusN<Ints>()), ...);
 }
 
 template <int D, typename E, typename... VertexTypes>

--- a/g2o/stuff/tuple_tools.h
+++ b/g2o/stuff/tuple_tools.h
@@ -25,28 +25,24 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <tuple>
+#include <utility>
+#include <type_traits>
+
 namespace g2o {
 
-template <int I>
-struct Tuple_apply_i {
-  template <typename F, typename T>
-  void operator()(F&& f, T& t, int i) {
-    if (i == I - 1)
-      f(std::get<I - 1>(t));
-    else
-      Tuple_apply_i<I - 1>()(f, t, i);
-  }
-};
+template<typename F, typename T, std::size_t... I>
+void tuple_apply_i_(F&& f, T& t, int i, std::index_sequence<I...>)
+{
+  (...,
+    ( I == i ? f(std::get<I>(t)) : void() )
+  );
+}
 
-template <>
-struct Tuple_apply_i<0> {
-  template <typename F, typename T>
-  void operator()(F&&, T&, int) {}
-};
-
-template <typename F, typename T>
-void tuple_apply_i(F&& f, T& t, int i) {
-  Tuple_apply_i<std::tuple_size<T>::value>()(f, t, i);
+template<typename F, typename T>
+void tuple_apply_i(F&& f, T& t, int i)
+{
+  tuple_apply_i_(f, t, i,
+    std::make_index_sequence<std::tuple_size_v<std::decay_t<T>>>());
 }
 
 }  // namespace g2o

--- a/g2o/stuff/tuple_tools.h
+++ b/g2o/stuff/tuple_tools.h
@@ -49,9 +49,4 @@ void tuple_apply_i(F&& f, T& t, int i) {
   Tuple_apply_i<std::tuple_size<T>::value>()(f, t, i);
 }
 
-template <typename Value, typename... Ts2>
-std::tuple<Ts2...> tuple_init(const Value& value, const std::tuple<Ts2...>&) {
-  return std::tuple<Ts2...>{Ts2{value}...};
-}
-
 }  // namespace g2o

--- a/unit_test/stuff/tuple_tools_tests.cpp
+++ b/unit_test/stuff/tuple_tools_tests.cpp
@@ -27,14 +27,6 @@
 #include "g2o/stuff/tuple_tools.h"
 #include "gtest/gtest.h"
 
-TEST(Stuff, Tuple_init) {
-  std::tuple<int, int, int> not_initialized;
-  auto initialized = g2o::tuple_init(1, not_initialized);
-  ASSERT_EQ(1, std::get<0>(initialized));
-  ASSERT_EQ(1, std::get<1>(initialized));
-  ASSERT_EQ(1, std::get<2>(initialized));
-}
-
 TEST(Stuff, Tuple_apply) {
   auto t = std::make_tuple(1, 2, 3);
   ASSERT_EQ(1, std::get<0>(t));


### PR DESCRIPTION
In the fixed sized edge code there is some quite difficult to read code to make the variadic templates work in c++14. Now that g2o moved to c++17, we can improve that a bit.
These changes use of folding as replacement of the awkward initialize-array trick.