### PR TITLE
Require spdlog 1.6 for cfg.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ find_package(QGLViewer)
 # Logging library
 option(G2O_USE_LOGGING "Try to use spdlog for logging" ON)
 if (G2O_USE_LOGGING)
-  find_package(spdlog)
+  find_package(spdlog 1.6)
   if (TARGET spdlog::spdlog OR TARGET spdlog::spdlog_header_only)
     set (G2O_HAVE_LOGGING 1)
     message(STATUS "Compiling with logging support")


### PR DESCRIPTION
spdlog/cfg/env.h is only available from version 1.6