### PR TITLE
Fix superscript

### DIFF
--- a/doc/g2o.tex
+++ b/doc/g2o.tex
@@ -1159,8 +1159,8 @@ following:
     \bh^\mathrm{l}_{t,i}(\bx^\mathrm{s}_t, \bx^\mathrm{l}_i)   & \doteq &
     \left(
     \begin{array}{c}
-        (x^\mathrm{s}_t - x_i)  \cos \theta^\mathrm{s}_t + (y^\mathrm{s}_t - y_i) \sin \theta^\mathrm{s}_t \\
-      - (x^\mathrm{s}_t - x_i)  \sin \theta^\mathrm{s}_t + (y^\mathrm{s}_t - y_i) \cos \theta^\mathrm{s}_t
+        (x^\mathrm{s}_t - x^\mathrm{l}_i)  \cos \theta^\mathrm{s}_t + (y^\mathrm{s}_t - y^\mathrm{l}_i) \sin \theta^\mathrm{s}_t \\
+      - (x^\mathrm{s}_t - x^\mathrm{l}_i)  \sin \theta^\mathrm{s}_t + (y^\mathrm{s}_t - y^\mathrm{l}_i) \cos \theta^\mathrm{s}_t
     \end{array}
     \right)
 \end{eqnarray}

--- a/doc/g2o.tex
+++ b/doc/g2o.tex
@@ -1179,7 +1179,7 @@ landmarks.
 In a similar way, we can define the error functions of an odometry
 edge connecting two robot poses $\bx^\mathrm{s}_t$ and
 $\bx^\mathrm{s}_{t+1}$. As stated before, an odometry measurement lives in $SE(2)$.
-By using the $\oplus$ operator we can write a synthetic measurement function:
+By using the $\ominus$ operator we can write a synthetic measurement function:
 \begin{eqnarray}
     \bh^\mathrm{s}_{t,t+1}(\bx^\mathrm{s}_t, \bx^\mathrm{s}_{t+1})   & \doteq & \bx^\mathrm{s}_{t+1} \ominus \bx^\mathrm{s}_{t}.
 \end{eqnarray}


### PR DESCRIPTION
Hey,

i was wondering whether the `g2o.pdf` has a mistake in equation 39.
I think that the superscript of the landmark coordinates is missing.

Can somebody confirm this please?
Thanks in advance!

Cheers!
Steve
EDIT:

I added a second fix on page 15