### PR TITLE
Change auto diff jacobian storage order when vertex dimension is 1

### DIFF
--- a/g2o/core/auto_differentiation.h
+++ b/g2o/core/auto_differentiation.h
@@ -158,7 +158,7 @@ class AutoDifferentiation {
   template <int EdgeDimension, int VertexDimension>
   using ADJacobianType =
       typename Eigen::Matrix<double, EdgeDimension, VertexDimension,
-                             Eigen::RowMajor>;
+                             (EdgeDimension > 1 && VertexDimension == 1) ? Eigen::ColMajor : Eigen::RowMajor>;
 
   //! helper for computing the error based on the functor in the edge
   static void computeError(Edge* that) {

--- a/g2o/core/auto_differentiation.h
+++ b/g2o/core/auto_differentiation.h
@@ -158,7 +158,9 @@ class AutoDifferentiation {
   template <int EdgeDimension, int VertexDimension>
   using ADJacobianType =
       typename Eigen::Matrix<double, EdgeDimension, VertexDimension,
-                             (EdgeDimension > 1 && VertexDimension == 1) ? Eigen::ColMajor : Eigen::RowMajor>;
+                             (EdgeDimension > 1 && VertexDimension == 1)
+                                 ? Eigen::ColMajor
+                                 : Eigen::RowMajor>;
 
   //! helper for computing the error based on the functor in the edge
   static void computeError(Edge* that) {


### PR DESCRIPTION
Hi, 
When I use audo diff with a one dimension vertex, Eigen generates a static assert and compilation fails.
It seems that Eigen does now allow Eigen::RowMajor if the column size is 1.
This patch changes the jacobian storage order if the vertex dimension is 1 to avoid this error.

Here is a reproducable example
 
```cpp
#include <g2o/core/auto_differentiation.h>
#include <g2o/core/base_unary_edge.h>
#include <g2o/types/slam2d/vertex_se2.h>

#include <Eigen/Core>
#include <vector>

class VertexTest : public g2o::BaseVertex<1, double> {};

class EdgeTest
    : public g2o::BaseUnaryEdge<2, Eigen::Vector2d, VertexTest> {
 public:
  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
  EdgeTest() {}
  template <typename T>
  bool operator()(const T *v, T *error) const {
    return true;
  }

  G2O_MAKE_AUTO_AD_FUNCTIONS_BY_GET
  bool read(std::istream &) override { return true; }
  bool write(std::ostream &os) const override { return os.good(); }
};

int main() {
}
```

```bash
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h: In instantiation of 'static void Eigen::PlainObjectBase<Derived>::_check_template_params() [with Derived = Eigen::Matrix<double, 2, 1, 1, 2, 1>]':
/usr/include/eigen3/Eigen/src/Core/Matrix.h:261:35:   required from 'Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix() [with _Scalar = double; int _Rows = 2; int _Cols = 1; int _Options = 1; int _MaxRows = 2; int _MaxCols = 1]'
/usr/include/c++/9/tuple:123:22:   required from 'constexpr std::_Head_base<_Idx, _Head, false>::_Head_base() [with long unsigned int _Idx = 0; _Head = Eigen::Matrix<double, 2, 1, 1, 2, 1>]'
/usr/include/c++/9/tuple:340:15:   required from 'static void g2o::AutoDifferentiation<Edge, EstimateAccess>::linearizeOplusNs(Edge*, std::index_sequence<Ints ...>) [with long unsigned int ...Ints = {0}; Edge = EdgeTest; EstimateAccess = g2o::EstimateAccessorGet<EdgeTest>; std::index_sequence<Ints ...> = std::integer_sequence<long unsigned int, 0>]'
third_party/g2o/g2o/core/auto_differentiation.h:180:21:   required from 'static void g2o::AutoDifferentiation<Edge, EstimateAccess>::linearize(Edge*) [with Edge = EdgeTest; EstimateAccess = g2o::EstimateAccessorGet<EdgeTest>]'
test.cpp:20:3:   required from here
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:903:7: error: static assertion failed: INVALID_MATRIX_TEMPLATE_PARAMETERS
  903 |       EIGEN_STATIC_ASSERT((EIGEN_IMPLIES(MaxRowsAtCompileTime==1 && MaxColsAtCompileTime!=1, (Options&RowMajor)==RowMajor)
      |       ^~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/test.dir/build.make:63: CMakeFiles/test.dir/src/test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1222: CMakeFiles/test.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```