### PR TITLE
disable new dtags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${g2o_LIBRARY_OUTPUT_DIRECTORY})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${g2o_LIBRARY_OUTPUT_DIRECTORY})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${g2o_RUNTIME_OUTPUT_DIRECTORY})
 
+# # Disable the --enable-new-dtags option for all targets, so that RPATH can be set.
+# # Many modern linkers, like Ninja, use the --enable-new-dtags option by default. 
+# # When this option is enabled, the -Wl,-rpath flag sets RUNPATH instead of RPATH. 
+# # This behavior is part of the ELF dynamic tags (DT_RUNPATH vs. DT_RPATH) and is intended 
+# # to give LD_LIBRARY_PATH precedence over RPATH, which was not the case with older linkers.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--disable-new-dtags")
+
 # Set standard installation directories
 set(RUNTIME_DESTINATION ${CMAKE_INSTALL_BINDIR})
 set(LIBRARY_DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
If another version of the g2o library is installed on your computer (e.g., as part of ROS 2) and the ROS 2 environment variables (including `LD_LIBRARY_PATH`) are sourced, leading to the linker prioritizing the ROS-installed version of the g2o library, even the `-Wl, -rpath` is specified in the linker. Since many modern linkers, like `Ninja` or `make`, use the `--enable-new-dtags` option by default. When this option is enabled, the `-Wl,-rpath` flag sets `RUNPATH` instead of `RPATH`. Thus, adjust the `CMakeLists.txt` accordingly.

Ps. When a program is executed, the dynamic linker looks for shared libraries in the following order:
- RPATH (Runtime Library Search Path)
- LD_LIBRARY_PATH
- RUNPATH
- Default System Directories