### PR TITLE
Establish compatibility with Eigen 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,7 +481,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${g2o_C_FLAGS}")
 # Find Eigen3. If it defines the target, this is used. If not,
 # fall back to the using the module form.
 # See https://eigen.tuxfamily.org/dox/TopicCMakeGuide.html for details
-find_package(Eigen3 3.4 REQUIRED)
+find_package(Eigen3 3.3 REQUIRED)
 if (TARGET Eigen3::Eigen)
   set(G2O_EIGEN3_EIGEN_TARGET Eigen3::Eigen)
 else()

--- a/g2o/types/slam3d/edge_se3_offset.cpp
+++ b/g2o/types/slam3d/edge_se3_offset.cpp
@@ -55,7 +55,7 @@ bool EdgeSE3Offset::resolveCaches() {
       resolveCache<CacheSE3Offset>(vertexXn<0>(), "CACHE_SE3_OFFSET", pv);
   pv[0] = parameters_[1];
   cacheTo_ =
-      resolveCache<CacheSE3Offset>(vertexXn<0>(), "CACHE_SE3_OFFSET", pv);
+      resolveCache<CacheSE3Offset>(vertexXn<1>(), "CACHE_SE3_OFFSET", pv);
   return (cacheFrom_ && cacheTo_);
 }
 
@@ -92,7 +92,8 @@ bool EdgeSE3Offset::setMeasurementFromState() {
 }
 
 void EdgeSE3Offset::linearizeOplus() {
-  // BaseBinaryEdge<6, SE3Quat, VertexSE3, VertexSE3>::linearizeOplus();
+  // BaseBinaryEdge<6, Isometry3, VertexSE3, VertexSE3>::linearizeOplus();
+  // return;
 
   VertexSE3* from = vertexXnRaw<0>();
   VertexSE3* to = vertexXnRaw<1>();


### PR DESCRIPTION
Implement a workaround to not use reshape() which was introduced in Eigen 3.4.