### PR TITLE
Fix `std::seed_seq::generate` usage to conform to the Standard

### DIFF
--- a/g2o/examples/sphere/create_sphere.cpp
+++ b/g2o/examples/sphere/create_sphere.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
   if (randomSeed) {
     std::random_device r;
     std::seed_seq seedSeq{r(), r(), r(), r(), r()};
-    vector<int> seeds(2);
+    vector<unsigned int> seeds(2);
     seedSeq.generate(seeds.begin(), seeds.end());
     cerr << "using seeds:";
     for (size_t i = 0; i < seeds.size(); ++i) cerr << " " << seeds[i];

--- a/g2o/stuff/sampler.h
+++ b/g2o/stuff/sampler.h
@@ -69,7 +69,7 @@ class GaussianSampler {
   }
   //! seed the random number generator, returns false if not having an own
   //! generator.
-  bool seed(int s) {
+  bool seed(unsigned int s) {
     if (!_generator) return false;
     _generator->seed(s);
     return true;


### PR DESCRIPTION
I work on Microsoft's C++ Standard Library implementation, where we build many popular open-source projects like yours with development builds of our compiler and libraries. This helps us find and fix bugs in our toolset before anyone else encounters them, and it also lets us provide advance notice of intentional breaking changes, which is the case here, as we found a bit of code in g2o that doesn't conform to the Standard.

[N4971](https://isocpp.org/files/papers/N4971.pdf) \[rand.util.seedseq\]/7 says:

> ```cpp
> template<class RandomAccessIterator>
>   void generate(RandomAccessIterator begin, RandomAccessIterator end);
> ```
> *Mandates:* `iterator_traits<RandomAccessIterator>::value_type` is an unsigned integer type capable of accommodating 32-bit quantities.

And \[structure.specifications\]/3.2 requires the library implementation to enforce this (e.g. with a `static_assert`):

> *Mandates:* the conditions that, if not met, render the program ill-formed.

We were missing such enforcement, until microsoft/STL#4447 which will ship in VS 2022 17.10 Preview 3.

This found that `g2o/examples/sphere/create_sphere.cpp` was using `seed_seq::generate` to fill a `vector<int>`, which is forbidden because `int` is a signed integer type. Changing this to `vector<unsigned int>` strictly follows the Standard's rules.

Additionally, these seed values were being passed to your `GaussianSampler::seed(int s)`, which in turn passes them to `std::mt19937::seed` without further manipulation. As `std::mt19937::seed` takes an unsigned 32-bit type, changing `GaussianSampler::seed` to take `unsigned int` makes everything consistent, avoiding value-modifying conversions back and forth, as well as avoiding any potential for sign-conversion compiler warnings. I searched for further cascading impacts of this change and didn't find any.

These changes are backwards-compatible with previous versions of MSVC, as well as portable to all other platforms.