### PR TITLE
Check if cmd arg file exist for g2o_viewer

### DIFF
--- a/g2o/apps/g2o_viewer/run_g2o_viewer.cpp
+++ b/g2o/apps/g2o_viewer/run_g2o_viewer.cpp
@@ -55,6 +55,12 @@ int RunG2OViewer::run(int argc, char** argv, CommandArgs& arg) {
                     "graph file which will be processed", true);
   arg.parseArgs(argc, argv);
 
+  // Check if given file exists
+  if (inputFilename.size() > 0 && !std::ifstream(inputFilename)) {
+    std::cerr << "Error: unable to open file " << inputFilename << std::endl;
+    std::exit(1);
+  }
+
   MainWindow mw;
   mw.updateDisplayedSolvers();
   mw.updateRobustKernels();


### PR DESCRIPTION
Hi All,

thanks for this awesome library and the continued support.

We have been working with g2o and g2o_viewer in the last months and normally open the graph files with the viewer providing them as command line argument. 

Unfortunately I am not perfect and sometimes provided an incorrect filename, which led to some wrong debugging as I rather questioned my code instead of the filename. 

Unfortunately g2o_viewer does not give an error message if the provided file does not exists. 
This would be something I would appreciate if this would be added.

Greetings Felix and Jan