### PR TITLE
Do not EXPORT executable targets

### DIFF
--- a/g2o/apps/g2o_cli/CMakeLists.txt
+++ b/g2o/apps/g2o_cli/CMakeLists.txt
@@ -27,12 +27,15 @@ target_link_libraries(g2o_cli_application g2o_cli_library)
 
 set_target_properties(g2o_cli_application PROPERTIES OUTPUT_NAME g2o)
 
-install(TARGETS g2o_cli_library g2o_cli_application
+install(TARGETS g2o_cli_library
   EXPORT ${G2O_TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION ${RUNTIME_DESTINATION}
   LIBRARY DESTINATION ${LIBRARY_DESTINATION}
   ARCHIVE DESTINATION ${ARCHIVE_DESTINATION}
   INCLUDES DESTINATION ${INCLUDES_DESTINATION}
+)
+install(TARGETS g2o_cli_application
+  RUNTIME DESTINATION ${RUNTIME_DESTINATION}
 )
 
 file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")

--- a/g2o/apps/g2o_simulator/CMakeLists.txt
+++ b/g2o/apps/g2o_simulator/CMakeLists.txt
@@ -46,12 +46,15 @@ add_executable(g2o_simulator3d_application
 target_link_libraries(g2o_simulator3d_application g2o_simulator_library types_slam3d_addons types_slam3d types_slam2d_addons types_slam2d core)
 set_target_properties(g2o_simulator3d_application PROPERTIES OUTPUT_NAME g2o_simulator3d)
 
-install(TARGETS g2o_simulator_library g2o_simulator2d_application g2o_simulator3d_application
+install(TARGETS g2o_simulator_library
   EXPORT ${G2O_TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION ${RUNTIME_DESTINATION}
   LIBRARY DESTINATION ${LIBRARY_DESTINATION}
   ARCHIVE DESTINATION ${ARCHIVE_DESTINATION}
   INCLUDES DESTINATION ${INCLUDES_DESTINATION}
+)
+install(TARGETS g2o_simulator2d_application g2o_simulator3d_application
+  RUNTIME DESTINATION ${RUNTIME_DESTINATION}
 )
 
 file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")

--- a/g2o/apps/g2o_viewer/CMakeLists.txt
+++ b/g2o/apps/g2o_viewer/CMakeLists.txt
@@ -40,12 +40,15 @@ target_link_libraries(viewer_library core g2o_cli_library ${QGLVIEWER_LIBRARY} $
 target_link_libraries(viewer_library core opengl_helper)
 target_link_libraries(g2o_viewer viewer_library)
 
-install(TARGETS g2o_viewer viewer_library
+install(TARGETS viewer_library
   EXPORT ${G2O_TARGETS_EXPORT_NAME}
   RUNTIME DESTINATION ${RUNTIME_DESTINATION}
   LIBRARY DESTINATION ${LIBRARY_DESTINATION}
   ARCHIVE DESTINATION ${ARCHIVE_DESTINATION}
   INCLUDES DESTINATION ${INCLUDES_DESTINATION} ${qt5_includes_dirs} ${QGLVIEWER_INCLUDE_DIR}
+)
+install(TARGETS g2o_viewer
+  RUNTIME DESTINATION ${RUNTIME_DESTINATION}
 )
 
 file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")


### PR DESCRIPTION
Adding executables to the exported targets means that their existance is required for any dependent project to use the generated cmake module, even though the executables are not required at compile/link-time.  This is normally fine when building from source, but runs into issues with distributions like RedHat or Debian, who split projects into multiple packages, such as g2o-cli, g2o-devel, g2o-plugins, etc.

There isn't any reason to require the executables to be present when linking against g2o libraries, so just remove them from the generated cmake module by dropping them from the exported target list.