### PR TITLE
Fix the crash issue caused by the destruction of static variables when exiting the app on iOS.

### DIFF
--- a/g2o/core/robust_kernel_factory.h
+++ b/g2o/core/robust_kernel_factory.h
@@ -139,13 +139,13 @@ class RegisterRobustKernelProxy {
 #define G2O_REGISTER_ROBUST_KERNEL(name, classname) \
   extern "C" void G2O_ROBUST_KERNEL_FACTORY_EXPORT  \
       g2o_robust_kernel_##classname(void) {}        \
-  static g2o::RegisterRobustKernelProxy<classname>  \
+  [[clang::no_destroy]] static g2o::RegisterRobustKernelProxy<classname>  \
       g_robust_kernel_proxy_##classname(#name);
 
 #define G2O_USE_ROBUST_KERNEL(classname)                            \
   extern "C" void G2O_ROBUST_KERNEL_FACTORY_IMPORT                  \
       g2o_robust_kernel_##classname(void);                          \
-  static g2o::ForceLinker g2o_force_robust_kernel_link_##classname( \
+  [[clang::no_destroy]] static g2o::ForceLinker g2o_force_robust_kernel_link_##classname( \
       g2o_robust_kernel_##classname);
 
 #endif

--- a/g2o/core/robust_kernel_factory.h
+++ b/g2o/core/robust_kernel_factory.h
@@ -136,16 +136,16 @@ class RegisterRobustKernelProxy {
 
 // These macros are used to automate registering of robust kernels and forcing
 // linkage
-#define G2O_REGISTER_ROBUST_KERNEL(name, classname) \
-  extern "C" void G2O_ROBUST_KERNEL_FACTORY_EXPORT  \
-      g2o_robust_kernel_##classname(void) {}        \
-  [[clang::no_destroy]] static g2o::RegisterRobustKernelProxy<classname>  \
+#define G2O_REGISTER_ROBUST_KERNEL(name, classname)                      \
+  extern "C" void G2O_ROBUST_KERNEL_FACTORY_EXPORT                       \
+      g2o_robust_kernel_##classname(void) {}                             \
+  [[clang::no_destroy]] static g2o::RegisterRobustKernelProxy<classname> \
       g_robust_kernel_proxy_##classname(#name);
 
-#define G2O_USE_ROBUST_KERNEL(classname)                            \
-  extern "C" void G2O_ROBUST_KERNEL_FACTORY_IMPORT                  \
-      g2o_robust_kernel_##classname(void);                          \
-  [[clang::no_destroy]] static g2o::ForceLinker g2o_force_robust_kernel_link_##classname( \
-      g2o_robust_kernel_##classname);
+#define G2O_USE_ROBUST_KERNEL(classname)           \
+  extern "C" void G2O_ROBUST_KERNEL_FACTORY_IMPORT \
+      g2o_robust_kernel_##classname(void);         \
+  [[clang::no_destroy]] static g2o::ForceLinker    \
+      g2o_force_robust_kernel_link_##classname(g2o_robust_kernel_##classname);
 
 #endif


### PR DESCRIPTION
crash backtrace:

0	xxx	std::__1::__tree_remove[abi:nn180100]<std::__1::__tree_node_base<void*>*>(0)
1	xxx	g2o::RobustKernelFactory::unregisterType(0)
2	libsystem_c.dylib	_exit()
3	BackBoardServices	___55-[BKSHIDEventDeliveryManager _initWithRemoteConnection]_block_invoke_3()
4	BoardServices	___31-[BSServiceConnection activate]_block_invoke.182()
5	BoardServices	___61-[BSXPCServiceConnectionEventHandler _connectionInvalidated:]_block_invoke()
6	BoardServices	_BSXPCServiceConnectionExecuteCallOut()
7	BoardServices	-[BSXPCServiceConnectionEventHandler _connectionInvalidated:]()
8	libdispatch.dylib	__dispatch_call_block_and_release()
9	libdispatch.dylib	__dispatch_client_callout()
10	libdispatch.dylib	__dispatch_lane_serial_drain()
11	libdispatch.dylib	__dispatch_lane_invoke()
12	libdispatch.dylib	__dispatch_root_queue_drain_deferred_wlh()
13	libdispatch.dylib	__dispatch_workloop_worker_thread()
14	libsystem_pthread.dylib	__pthread_wqthread()