### PR TITLE
Update sparse_optimizer.cpp for cpp20 compile error with fmt

### DIFF
--- a/g2o/core/sparse_optimizer.cpp
+++ b/g2o/core/sparse_optimizer.cpp
@@ -507,8 +507,8 @@ bool SparseOptimizer::updateInitialization(HyperGraph::VertexSet& vset,
   }
 
   if (newVertices.size() != vset.size()) {
-    G2O_ERROR(fmt::runtime("{}: something went wrong, size mismatch {} != {}"), vset.size(),
-              newVertices.size());
+    G2O_ERROR(fmt::runtime("{}: something went wrong, size mismatch {} != {}"),
+              vset.size(), newVertices.size());
   }
   return _algorithm->updateStructure(newVertices, eset);
 }

--- a/g2o/core/sparse_optimizer.cpp
+++ b/g2o/core/sparse_optimizer.cpp
@@ -507,7 +507,7 @@ bool SparseOptimizer::updateInitialization(HyperGraph::VertexSet& vset,
   }
 
   if (newVertices.size() != vset.size()) {
-    G2O_ERROR("{}: something went wrong, size mismatch {} != {}", vset.size(),
+    G2O_ERROR(fmt::runtime("{}: something went wrong, size mismatch {} != {}"), vset.size(),
               newVertices.size());
   }
   return _algorithm->updateStructure(newVertices, eset);


### PR DESCRIPTION
When compiling g2o with cpp20, there is an error:
In member function ‘virtual bool g2o::SparseOptimizer::updateInitialization(g2o::HyperGraph::VertexSet&, g2o::HyperGraph::EdgeSet&)’:
/home/aokiji/Downloads/g2o/g2o/core/sparse_optimizer.cpp:510:5:   in ‘constexpr’ expansion of ‘fmt::v9::basic_format_string<char, long unsigned int, long unsigned int>("{}: something went wrong, size mismatch {} != {}")’
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:3159:40:   in ‘constexpr’ expansion of ‘fmt::v9::detail::parse_format_string<true, char, fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int> >(((fmt::v9::basic_format_string<char, long unsigned int, long unsigned int>*)this)->fmt::v9::basic_format_string<char, long unsigned int, long unsigned int>::str_, fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int>(fmt::v9::basic_string_view<char>(((const char*)s)), (fmt::v9::detail::error_handler(), fmt::v9::detail::error_handler())))’
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:2722:36:   in ‘constexpr’ expansion of ‘fmt::v9::detail::parse_replacement_field<char, fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int>&>(p, end, (* & handler))’
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:2653:51:   in ‘constexpr’ expansion of ‘(& handler)->fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int>::on_arg_id()’
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:2962:70:   in ‘constexpr’ expansion of ‘((fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int>*)this)->fmt::v9::detail::format_string_checker<char, fmt::v9::detail::error_handler, long unsigned int, long unsigned int>::context_.fmt::v9::detail::compile_parse_context<char, fmt::v9::detail::error_handler>::next_arg_id()’
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:747:40: error: ‘constexpr void fmt::v9::basic_format_parse_context<Char, ErrorHandler>::on_error(const char*) [with Char = char; ErrorHandler = fmt::v9::detail::error_handler]’ called in a constant expression
  747 |     if (id >= num_args_) this->on_error("argument not found");
      |                          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:717:22: note: ‘constexpr void fmt::v9::basic_format_parse_context<Char, ErrorHandler>::on_error(const char*) [with Char = char; ErrorHandler = fmt::v9::detail::error_handler]’ is not usable as a ‘constexpr’ function because:
  717 |   FMT_CONSTEXPR void on_error(const char* message) {
      |                      ^~~~~~~~
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:718:27: error: call to non-‘constexpr’ function ‘void fmt::v9::detail::error_handler::on_error(const char*)’
  718 |     ErrorHandler::on_error(message);
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/home/aokiji/Downloads/g2o/spdlog-1.11.0/include/spdlog/fmt/bundled/core.h:637:21: note: ‘void fmt::v9::detail::error_handler::on_error(const char*)’ declared here
  637 |   FMT_NORETURN void on_error(const char* message) {