### PR TITLE
Update libQGLViewer link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ following packages.
 -   spdlog <https://github.com/gabime/spdlog>
 -   suitesparse <http://faculty.cse.tamu.edu/davis/suitesparse.html>
 -   Qt5 <http://qt-project.org>
--   libQGLViewer <http://www.libqglviewer.com>
+-   libQGLViewer <https://gillesdebunne.github.io/libQGLViewer/>
 
 On Ubuntu / Debian these dependencies are resolved by installing the
 following packages.


### PR DESCRIPTION
Update link that has had domain expired and domain-squatted