### PR TITLE
Use correct value for measurementDimension.

### DIFF
--- a/g2o/types/slam2d/edge_se2_pointxy_offset.h
+++ b/g2o/types/slam2d/edge_se2_pointxy_offset.h
@@ -64,7 +64,7 @@ class G2O_TYPES_SLAM2D_API EdgeSE2PointXYOffset
     return true;
   }
 
-  virtual int measurementDimension() const { return 3; }
+  virtual int measurementDimension() const { return 2; }
 
   virtual bool setMeasurementFromState();
 


### PR DESCRIPTION
EdgeSE2PointXYOffset advertises the measurement dimension to be 3 when, in fact, it's 2.