### PR TITLE
serialization fixes

### DIFF
--- a/g2o/core/base_edge.h
+++ b/g2o/core/base_edge.h
@@ -171,12 +171,12 @@ class BaseEdge : public OptimizableGraph::Edge {
   //! reads the upper triangular part of the matrix and recovers the missing
   //! symmetrical elements
   bool readInformationMatrix(std::istream& is) {
-    for (int i = 0; i < information().rows() && is.good(); ++i)
-      for (int j = i; j < information().cols() && is.good(); ++j) {
+    for (int i = 0; i < information().rows() && !is.fail(); ++i)
+      for (int j = i; j < information().cols() && !is.fail(); ++j) {
         is >> information()(i, j);
         if (i != j) information()(j, i) = information()(i, j);
       }
-    return is.good() || is.eof();
+    return !is.fail();
   }
   //! write the param IDs that are potentially used by the edge
   bool writeParamIds(std::ostream& os) const {
@@ -190,7 +190,7 @@ class BaseEdge : public OptimizableGraph::Edge {
       is >> paramId;
       setParameterId(i, paramId);
     }
-    return is.good() || is.eof();
+    return !is.fail();
   }
 
  public:

--- a/g2o/core/io_helper.h
+++ b/g2o/core/io_helper.h
@@ -40,8 +40,8 @@ bool writeVector(std::ostream& os, const Eigen::DenseBase<Derived>& b) {
 
 template <typename Derived>
 bool readVector(std::istream& is, Eigen::DenseBase<Derived>& b) {
-  for (int i = 0; i < b.size() && is.good(); i++) is >> b(i);
-  return is.good() || is.eof();
+  for (int i = 0; i < b.size() && !is.fail(); i++) is >> b(i);
+  return !is.fail();
 }
 }  // namespace internal
 }  // namespace g2o

--- a/g2o/types/sba/edge_project_p2mc.cpp
+++ b/g2o/types/sba/edge_project_p2mc.cpp
@@ -41,9 +41,8 @@ bool EdgeProjectP2MC::read(std::istream& is) {
 }
 
 bool EdgeProjectP2MC::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  writeInformationMatrix(os);
-  return os.good();
+  if (!internal::writeVector(os, measurement())) return false;
+  return writeInformationMatrix(os);
 }
 
 void EdgeProjectP2MC::computeError() {

--- a/g2o/types/sba/edge_project_p2sc.cpp
+++ b/g2o/types/sba/edge_project_p2sc.cpp
@@ -35,14 +35,13 @@ EdgeProjectP2SC::EdgeProjectP2SC()
     : BaseBinaryEdge<3, Vector3, VertexPointXYZ, VertexCam>() {}
 
 bool EdgeProjectP2SC::read(std::istream& is) {
-  internal::readVector(is, _measurement);
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 
 bool EdgeProjectP2SC::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  writeInformationMatrix(os);
-  return os.good();
+  if (!internal::writeVector(os, measurement())) return false;
+  return writeInformationMatrix(os);
 }
 
 // return the error estimate as a 2-vector

--- a/g2o/types/sba/edge_sba_scale.cpp
+++ b/g2o/types/sba/edge_sba_scale.cpp
@@ -35,15 +35,16 @@ EdgeSBAScale::EdgeSBAScale()
 bool EdgeSBAScale::read(std::istream& is) {
   double meas;
   is >> meas;
+  if (is.fail()) return false;
   setMeasurement(meas);
   information().setIdentity();
   is >> information()(0, 0);
-  return true;
+  return !is.fail();
 }
 
 bool EdgeSBAScale::write(std::ostream& os) const {
   os << measurement() << " " << information()(0, 0);
-  return os.good();
+  return !os.fail();
 }
 
 void EdgeSBAScale::initialEstimate(const OptimizableGraph::VertexSet& from_,

--- a/g2o/types/sba/edge_se3_expmap.cpp
+++ b/g2o/types/sba/edge_se3_expmap.cpp
@@ -39,7 +39,8 @@ bool EdgeSE3Expmap::read(std::istream& is) {
 }
 
 bool EdgeSE3Expmap::write(std::ostream& os) const {
-  if (!internal::writeVector(os, measurement().inverse().toVector())) return false;
+  if (!internal::writeVector(os, measurement().inverse().toVector()))
+    return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/sba/edge_se3_expmap.cpp
+++ b/g2o/types/sba/edge_se3_expmap.cpp
@@ -33,13 +33,13 @@ EdgeSE3Expmap::EdgeSE3Expmap()
 
 bool EdgeSE3Expmap::read(std::istream& is) {
   Vector7 meas;
-  internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   setMeasurement(SE3Quat(meas).inverse());
   return readInformationMatrix(is);
 }
 
 bool EdgeSE3Expmap::write(std::ostream& os) const {
-  internal::writeVector(os, measurement().inverse().toVector());
+  if (!internal::writeVector(os, measurement().inverse().toVector())) return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/sba/parameter_cameraparameters.cpp
+++ b/g2o/types/sba/parameter_cameraparameters.cpp
@@ -41,18 +41,13 @@ CameraParameters::CameraParameters(double focal_length,
       baseline(baseline) {}
 
 bool CameraParameters::read(std::istream& is) {
-  is >> focal_length
-     >> principle_point[0]
-     >> principle_point[1]
-     >> baseline;
+  is >> focal_length >> principle_point[0] >> principle_point[1] >> baseline;
   return !is.fail();
 }
 
 bool CameraParameters::write(std::ostream& os) const {
-  os << focal_length << " "
-     << principle_point.x() << " "
-     << principle_point.y() << " "
-     << baseline << " ";
+  os << focal_length << " " << principle_point.x() << " " << principle_point.y()
+     << " " << baseline << " ";
   return !os.fail();
 }
 

--- a/g2o/types/sba/parameter_cameraparameters.cpp
+++ b/g2o/types/sba/parameter_cameraparameters.cpp
@@ -41,19 +41,19 @@ CameraParameters::CameraParameters(double focal_length,
       baseline(baseline) {}
 
 bool CameraParameters::read(std::istream& is) {
-  is >> focal_length;
-  is >> principle_point[0];
-  is >> principle_point[1];
-  is >> baseline;
-  return true;
+  is >> focal_length
+     >> principle_point[0]
+     >> principle_point[1]
+     >> baseline;
+  return !is.fail();
 }
 
 bool CameraParameters::write(std::ostream& os) const {
-  os << focal_length << " ";
-  os << principle_point.x() << " ";
-  os << principle_point.y() << " ";
-  os << baseline << " ";
-  return true;
+  os << focal_length << " "
+     << principle_point.x() << " "
+     << principle_point.y() << " "
+     << baseline << " ";
+  return !os.fail();
 }
 
 Vector2 CameraParameters::cam_map(const Vector3& trans_xyz) const {

--- a/g2o/types/sba/vertex_se3_expmap.cpp
+++ b/g2o/types/sba/vertex_se3_expmap.cpp
@@ -34,7 +34,7 @@ VertexSE3Expmap::VertexSE3Expmap() : BaseVertex<6, SE3Quat>() {}
 
 bool VertexSE3Expmap::read(std::istream& is) {
   Vector7 est;
-  internal::readVector(is, est);
+  if (!internal::readVector(is, est)) return false;
   setEstimate(SE3Quat(est).inverse());
   return true;
 }

--- a/g2o/types/slam2d/edge_pointxy.cpp
+++ b/g2o/types/slam2d/edge_pointxy.cpp
@@ -41,10 +41,9 @@ EdgePointXY::EdgePointXY()
 
 bool EdgePointXY::read(std::istream& is) {
   Vector2 p;
-  internal::readVector(is, p);
+  if (!internal::readVector(is, p)) return false;
   setMeasurement(p);
-  readInformationMatrix(is);
-  return true;
+  return readInformationMatrix(is);
 }
 
 bool EdgePointXY::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_se2.cpp
+++ b/g2o/types/slam2d/edge_se2.cpp
@@ -37,11 +37,10 @@ EdgeSE2::EdgeSE2() : BaseBinaryEdge<3, SE2, VertexSE2, VertexSE2>() {}
 
 bool EdgeSE2::read(std::istream& is) {
   Vector3 p;
-  internal::readVector(is, p);
+  if (!internal::readVector(is, p)) return false;
   setMeasurement(SE2(p));
   _inverseMeasurement = measurement().inverse();
-  readInformationMatrix(is);
-  return is.good() || is.eof();
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE2::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_se2_lotsofxy.cpp
+++ b/g2o/types/slam2d/edge_se2_lotsofxy.cpp
@@ -55,6 +55,7 @@ void EdgeSE2LotsOfXY::computeError() {
 
 bool EdgeSE2LotsOfXY::read(std::istream& is) {
   is >> _observedPoints;
+  if (is.fail()) return false;
   setSize(_observedPoints + 1);
 
   // read the measurements
@@ -62,15 +63,18 @@ bool EdgeSE2LotsOfXY::read(std::istream& is) {
     unsigned int index = 2 * i;
     is >> _measurement[index] >> _measurement[index + 1];
   }
+  if (is.fail()) return false;
 
-  // read the information matrix
+  // read the upper triangle of the information matrix
   for (unsigned int i = 0; i < _observedPoints * 2; i++) {
-    // fill the "upper triangle" part of the matrix
     for (unsigned int j = i; j < _observedPoints * 2; j++) {
       is >> information()(i, j);
     }
+  }
+  if (is.fail()) return false;
 
-    // fill the lower triangle part
+  // mirror to fill the lower triangle
+  for (unsigned int i = 0; i < _observedPoints * 2; i++) {
     for (unsigned int j = 0; j < i; j++) {
       information()(i, j) = information()(j, i);
     }
@@ -96,7 +100,7 @@ bool EdgeSE2LotsOfXY::write(std::ostream& os) const {
     }
   }
 
-  return os.good();
+  return !os.fail();
 }
 
 void EdgeSE2LotsOfXY::linearizeOplus() {

--- a/g2o/types/slam2d/edge_se2_offset.cpp
+++ b/g2o/types/slam2d/edge_se2_offset.cpp
@@ -66,13 +66,14 @@ bool EdgeSE2Offset::read(std::istream& is) {
   if (!setParameterId(1, pidTo)) return false;
 
   Vector3 meas;
-  internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   setMeasurement(SE2(meas));
-  if (is.bad()) return false;
-  readInformationMatrix(is);
-  if (is.bad()) {
-    //  we overwrite the information matrix with the Identity
+
+  // Information-matrix read is best-effort: legacy graph files sometimes
+  // omit it, so fall back to identity rather than failing the edge.
+  if (!readInformationMatrix(is)) {
     information().setIdentity();
+    is.clear();
   }
   return true;
 }

--- a/g2o/types/slam2d/edge_se2_pointxy.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy.cpp
@@ -39,9 +39,8 @@ EdgeSE2PointXY::EdgeSE2PointXY()
     : BaseBinaryEdge<2, Vector2, VertexSE2, VertexPointXY>() {}
 
 bool EdgeSE2PointXY::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  readInformationMatrix(is);
-  return true;
+  if (!internal::readVector(is, _measurement)) return false;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE2PointXY::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_bearing.cpp
@@ -74,12 +74,12 @@ void EdgeSE2PointXYBearing::linearizeOplus() {
 
 bool EdgeSE2PointXYBearing::read(std::istream& is) {
   is >> _measurement >> information()(0, 0);
-  return true;
+  return !is.fail();
 }
 
 bool EdgeSE2PointXYBearing::write(std::ostream& os) const {
   os << measurement() << " " << information()(0, 0);
-  return os.good();
+  return !os.fail();
 }
 
 EdgeSE2PointXYBearingWriteGnuplotAction::

--- a/g2o/types/slam2d/edge_se2_pointxy_calib.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_calib.cpp
@@ -47,9 +47,8 @@ void EdgeSE2PointXYCalib::initialEstimate(
 }
 
 bool EdgeSE2PointXYCalib::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  readInformationMatrix(is);
-  return true;
+  if (!internal::readVector(is, _measurement)) return false;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE2PointXYCalib::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_se2_pointxy_offset.cpp
+++ b/g2o/types/slam2d/edge_se2_pointxy_offset.cpp
@@ -55,19 +55,22 @@ bool EdgeSE2PointXYOffset::resolveCaches() {
 bool EdgeSE2PointXYOffset::read(std::istream& is) {
   int pId;
   is >> pId;
-  setParameterId(0, pId);
+  if (!setParameterId(0, pId)) return false;
   // measured keypoint
-  internal::readVector(is, _measurement);
-  if (is.bad()) return false;
-  readInformationMatrix(is);
-  //  we overwrite the information matrix in case of read errors
-  if (is.bad()) information().setIdentity();
+  if (!internal::readVector(is, _measurement)) return false;
+
+  // Information-matrix read is best-effort: legacy graph files sometimes
+  // omit it, so fall back to identity rather than failing the edge.
+  if (!readInformationMatrix(is)) {
+    information().setIdentity();
+    is.clear();
+  }
   return true;
 }
 
 bool EdgeSE2PointXYOffset::write(std::ostream& os) const {
   os << offsetParam->id() << " ";
-  internal::writeVector(os, measurement());
+  if (!internal::writeVector(os, measurement())) return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/slam2d/edge_se2_prior.cpp
+++ b/g2o/types/slam2d/edge_se2_prior.cpp
@@ -43,11 +43,10 @@ void EdgeSE2Prior::initialEstimate(const OptimizableGraph::VertexSet& from,
 
 bool EdgeSE2Prior::read(std::istream& is) {
   Vector3 p;
-  internal::readVector(is, p);
+  if (!internal::readVector(is, p)) return false;
   setMeasurement(p);
   _inverseMeasurement = _measurement.inverse();
-  readInformationMatrix(is);
-  return true;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE2Prior::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_se2_twopointsxy.cpp
+++ b/g2o/types/slam2d/edge_se2_twopointsxy.cpp
@@ -56,10 +56,12 @@ void EdgeSE2TwoPointsXY::computeError() {
 bool EdgeSE2TwoPointsXY::read(std::istream& is) {
   is >> _measurement[0] >> _measurement[1] >> _measurement[2] >>
       _measurement[3];
+  if (is.fail()) return false;
   is >> information()(0, 0) >> information()(0, 1) >> information()(0, 2) >>
       information()(0, 3) >> information()(1, 1) >> information()(1, 2) >>
       information()(1, 3) >> information()(2, 2) >> information()(2, 3) >>
       information()(3, 3);
+  if (is.fail()) return false;
   information()(1, 0) = information()(0, 1);
   information()(2, 0) = information()(0, 2);
   information()(2, 1) = information()(1, 2);
@@ -77,7 +79,7 @@ bool EdgeSE2TwoPointsXY::write(std::ostream& os) const {
      << information()(1, 1) << " " << information()(1, 2) << " "
      << information()(1, 3) << " " << information()(2, 2) << " "
      << information()(2, 3) << " " << information()(3, 3);
-  return os.good();
+  return !os.fail();
 }
 
 void EdgeSE2TwoPointsXY::initialEstimate(

--- a/g2o/types/slam2d/edge_se2_xyprior.cpp
+++ b/g2o/types/slam2d/edge_se2_xyprior.cpp
@@ -32,9 +32,8 @@ EdgeSE2XYPrior::EdgeSE2XYPrior()
     : BaseUnaryEdge<2, Vector2, g2o::VertexSE2>() {}
 
 bool EdgeSE2XYPrior::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  readInformationMatrix(is);
-  return true;
+  if (!internal::readVector(is, _measurement)) return false;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE2XYPrior::write(std::ostream& os) const {

--- a/g2o/types/slam2d/edge_xy_prior.cpp
+++ b/g2o/types/slam2d/edge_xy_prior.cpp
@@ -39,9 +39,8 @@ EdgeXYPrior::EdgeXYPrior() : BaseUnaryEdge<2, Vector2, VertexPointXY>() {
 }
 
 bool EdgeXYPrior::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  readInformationMatrix(is);
-  return true;
+  if (!internal::readVector(is, _measurement)) return false;
+  return readInformationMatrix(is);
 }
 
 bool EdgeXYPrior::write(std::ostream& os) const {

--- a/g2o/types/slam2d_addons/edge_line2d_pointxy.cpp
+++ b/g2o/types/slam2d_addons/edge_line2d_pointxy.cpp
@@ -32,15 +32,13 @@ EdgeLine2DPointXY::EdgeLine2DPointXY()
     : BaseBinaryEdge<1, double, VertexLine2D, VertexPointXY>() {}
 
 bool EdgeLine2DPointXY::read(std::istream& is) {
-  is >> _measurement;
-  is >> information()(0, 0);
-  return true;
+  is >> _measurement >> information()(0, 0);
+  return !is.fail();
 }
 
 bool EdgeLine2DPointXY::write(std::ostream& os) const {
-  os << measurement() << " ";
-  os << information()(0, 0);
-  return os.good();
+  os << measurement() << " " << information()(0, 0);
+  return !os.fail();
 }
 
 }  // namespace g2o

--- a/g2o/types/slam2d_addons/vertex_line2d.cpp
+++ b/g2o/types/slam2d_addons/vertex_line2d.cpp
@@ -40,12 +40,12 @@ VertexLine2D::VertexLine2D() : BaseVertex<2, Line2D>(), p1Id(-1), p2Id(-1) {
 
 bool VertexLine2D::read(std::istream& is) {
   is >> _estimate[0] >> _estimate[1] >> p1Id >> p2Id;
-  return true;
+  return !is.fail();
 }
 
 bool VertexLine2D::write(std::ostream& os) const {
   os << estimate()(0) << " " << estimate()(1) << " " << p1Id << " " << p2Id;
-  return os.good();
+  return !os.fail();
 }
 
 #ifdef G2O_HAVE_OPENGL

--- a/g2o/types/slam3d/edge_pointxyz.cpp
+++ b/g2o/types/slam3d/edge_pointxyz.cpp
@@ -37,11 +37,16 @@ EdgePointXYZ::EdgePointXYZ()
 bool EdgePointXYZ::read(std::istream& is) {
   Vector3 p;
   is >> p[0] >> p[1] >> p[2];
+  if (is.fail()) return false;
   setMeasurement(p);
   for (int i = 0; i < 3; ++i)
     for (int j = i; j < 3; ++j) {
       is >> information()(i, j);
-      if (i != j) information()(j, i) = information()(i, j);
+    }
+  if (is.fail()) return false;
+  for (int i = 0; i < 3; ++i)
+    for (int j = i + 1; j < 3; ++j) {
+      information()(j, i) = information()(i, j);
     }
   return true;
 }
@@ -51,7 +56,7 @@ bool EdgePointXYZ::write(std::ostream& os) const {
   os << p.x() << " " << p.y() << " " << p.z();
   for (int i = 0; i < 3; ++i)
     for (int j = i; j < 3; ++j) os << " " << information()(i, j);
-  return os.good();
+  return !os.fail();
 }
 
 #ifndef NUMERIC_JACOBIAN_THREE_D_TYPES

--- a/g2o/types/slam3d/edge_se3.cpp
+++ b/g2o/types/slam3d/edge_se3.cpp
@@ -42,14 +42,12 @@ EdgeSE3::EdgeSE3() : BaseBinaryEdge<6, Isometry3, VertexSE3, VertexSE3>() {
 
 bool EdgeSE3::read(std::istream& is) {
   Vector7 meas;
-  internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   // normalize the quaternion to recover numerical precision lost by storing as
   // human readable text
   Vector4::MapType(meas.data() + 3).normalize();
   setMeasurement(internal::fromVectorQT(meas));
-  if (is.bad()) return false;
-  readInformationMatrix(is);
-  return is.good() || is.eof();
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE3::write(std::ostream& os) const {

--- a/g2o/types/slam3d/edge_se3_lotsofxyz.cpp
+++ b/g2o/types/slam3d/edge_se3_lotsofxyz.cpp
@@ -112,6 +112,7 @@ void EdgeSE3LotsOfXYZ::linearizeOplus() {
 
 bool EdgeSE3LotsOfXYZ::read(std::istream& is) {
   is >> _observedPoints;
+  if (is.fail()) return false;
 
   setSize(_observedPoints + 1);
 
@@ -121,15 +122,18 @@ bool EdgeSE3LotsOfXYZ::read(std::istream& is) {
     is >> _measurement[index] >> _measurement[index + 1] >>
         _measurement[index + 2];
   }
+  if (is.fail()) return false;
 
-  // read the information matrix
+  // read the upper triangle of the information matrix
   for (unsigned int i = 0; i < _observedPoints * 3; i++) {
-    // fill the "upper triangle" part of the matrix
     for (unsigned int j = i; j < _observedPoints * 3; j++) {
       is >> information()(i, j);
     }
+  }
+  if (is.fail()) return false;
 
-    // fill the lower triangle part
+  // mirror to fill the lower triangle
+  for (unsigned int i = 0; i < _observedPoints * 3; i++) {
     for (unsigned int j = 0; j < i; j++) {
       information()(i, j) = information()(j, i);
     }
@@ -154,7 +158,7 @@ bool EdgeSE3LotsOfXYZ::write(std::ostream& os) const {
       os << " " << information()(i, j);
     }
   }
-  return os.good();
+  return !os.fail();
 }
 
 void EdgeSE3LotsOfXYZ::initialEstimate(const OptimizableGraph::VertexSet& fixed,

--- a/g2o/types/slam3d/edge_se3_offset.cpp
+++ b/g2o/types/slam3d/edge_se3_offset.cpp
@@ -61,24 +61,22 @@ bool EdgeSE3Offset::resolveCaches() {
 }
 
 bool EdgeSE3Offset::read(std::istream& is) {
-  bool state = readParamIds(is);
+  if (!readParamIds(is)) return false;
 
   Vector7 meas;
-  state &= internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   // normalize the quaternion to recover numerical precision lost by storing as
   // human readable text
   Vector4::MapType(meas.data() + 3).normalize();
   setMeasurement(internal::fromVectorQT(meas));
 
-  state &= readInformationMatrix(is);
-  return state;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE3Offset::write(std::ostream& os) const {
-  writeParamIds(os);
-  internal::writeVector(os, internal::toVectorQT(_measurement));
-  writeInformationMatrix(os);
-  return os.good();
+  if (!writeParamIds(os)) return false;
+  if (!internal::writeVector(os, internal::toVectorQT(_measurement))) return false;
+  return writeInformationMatrix(os);
 }
 
 void EdgeSE3Offset::computeError() {

--- a/g2o/types/slam3d/edge_se3_offset.cpp
+++ b/g2o/types/slam3d/edge_se3_offset.cpp
@@ -75,7 +75,8 @@ bool EdgeSE3Offset::read(std::istream& is) {
 
 bool EdgeSE3Offset::write(std::ostream& os) const {
   if (!writeParamIds(os)) return false;
-  if (!internal::writeVector(os, internal::toVectorQT(_measurement))) return false;
+  if (!internal::writeVector(os, internal::toVectorQT(_measurement)))
+    return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/slam3d/edge_se3_pointxyz.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz.cpp
@@ -63,19 +63,17 @@ bool EdgeSE3PointXYZ::resolveCaches() {
 }
 
 bool EdgeSE3PointXYZ::read(std::istream& is) {
-  readParamIds(is);
+  if (!readParamIds(is)) return false;
   Vector3 meas;
-  internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   setMeasurement(meas);
-  readInformationMatrix(is);
-  return is.good() || is.eof();
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE3PointXYZ::write(std::ostream& os) const {
-  bool state = writeParamIds(os);
-  state &= internal::writeVector(os, measurement());
-  state &= writeInformationMatrix(os);
-  return state;
+  if (!writeParamIds(os)) return false;
+  if (!internal::writeVector(os, measurement())) return false;
+  return writeInformationMatrix(os);
 }
 
 void EdgeSE3PointXYZ::computeError() {

--- a/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
@@ -51,7 +51,8 @@ bool EdgeSE3PointXYZDepth::resolveCaches() {
 
 bool EdgeSE3PointXYZDepth::read(std::istream& is) {
   if (!readParamIds(is)) return false;
-  if (!internal::readVector(is, _measurement)) return false;  // measured keypoint
+  if (!internal::readVector(is, _measurement))
+    return false;  // measured keypoint
   return readInformationMatrix(is);
 }
 

--- a/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_depth.cpp
@@ -50,14 +50,14 @@ bool EdgeSE3PointXYZDepth::resolveCaches() {
 }
 
 bool EdgeSE3PointXYZDepth::read(std::istream& is) {
-  readParamIds(is);
-  internal::readVector(is, _measurement);  // measured keypoint
+  if (!readParamIds(is)) return false;
+  if (!internal::readVector(is, _measurement)) return false;  // measured keypoint
   return readInformationMatrix(is);
 }
 
 bool EdgeSE3PointXYZDepth::write(std::ostream& os) const {
-  writeParamIds(os);
-  internal::writeVector(os, measurement());
+  if (!writeParamIds(os)) return false;
+  if (!internal::writeVector(os, measurement())) return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
+++ b/g2o/types/slam3d/edge_se3_pointxyz_disparity.cpp
@@ -58,14 +58,14 @@ bool EdgeSE3PointXYZDisparity::resolveCaches() {
 }
 
 bool EdgeSE3PointXYZDisparity::read(std::istream& is) {
-  readParamIds(is);
-  internal::readVector(is, _measurement);
+  if (!readParamIds(is)) return false;
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 
 bool EdgeSE3PointXYZDisparity::write(std::ostream& os) const {
-  writeParamIds(os);
-  internal::writeVector(os, measurement());
+  if (!writeParamIds(os)) return false;
+  if (!internal::writeVector(os, measurement())) return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/slam3d/edge_se3_prior.cpp
+++ b/g2o/types/slam3d/edge_se3_prior.cpp
@@ -54,19 +54,17 @@ bool EdgeSE3Prior::resolveCaches() {
 }
 
 bool EdgeSE3Prior::read(std::istream& is) {
-  bool state = readParamIds(is);
+  if (!readParamIds(is)) return false;
   Vector7 meas;
-  state &= internal::readVector(is, meas);
+  if (!internal::readVector(is, meas)) return false;
   setMeasurement(internal::fromVectorQT(meas));
-  state &= readInformationMatrix(is);
-  return state;
+  return readInformationMatrix(is);
 }
 
 bool EdgeSE3Prior::write(std::ostream& os) const {
-  writeParamIds(os);
-  internal::writeVector(os, internal::toVectorQT(measurement()));
-  writeInformationMatrix(os);
-  return os.good();
+  if (!writeParamIds(os)) return false;
+  if (!internal::writeVector(os, internal::toVectorQT(measurement()))) return false;
+  return writeInformationMatrix(os);
 }
 
 void EdgeSE3Prior::computeError() {

--- a/g2o/types/slam3d/edge_se3_prior.cpp
+++ b/g2o/types/slam3d/edge_se3_prior.cpp
@@ -63,7 +63,8 @@ bool EdgeSE3Prior::read(std::istream& is) {
 
 bool EdgeSE3Prior::write(std::ostream& os) const {
   if (!writeParamIds(os)) return false;
-  if (!internal::writeVector(os, internal::toVectorQT(measurement()))) return false;
+  if (!internal::writeVector(os, internal::toVectorQT(measurement())))
+    return false;
   return writeInformationMatrix(os);
 }
 

--- a/g2o/types/slam3d/edge_se3_xyzprior.cpp
+++ b/g2o/types/slam3d/edge_se3_xyzprior.cpp
@@ -50,8 +50,8 @@ bool EdgeSE3XYZPrior::resolveCaches() {
 }
 
 bool EdgeSE3XYZPrior::read(std::istream& is) {
-  readParamIds(is);
-  internal::readVector(is, _measurement);
+  if (!readParamIds(is)) return false;
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 

--- a/g2o/types/slam3d/edge_xyz_prior.cpp
+++ b/g2o/types/slam3d/edge_xyz_prior.cpp
@@ -36,7 +36,7 @@ EdgeXYZPrior::EdgeXYZPrior() : BaseUnaryEdge<3, Vector3, VertexPointXYZ>() {
 }
 
 bool EdgeXYZPrior::read(std::istream& is) {
-  internal::readVector(is, _measurement);
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 

--- a/g2o/types/slam3d/parameter_camera.cpp
+++ b/g2o/types/slam3d/parameter_camera.cpp
@@ -76,9 +76,7 @@ bool ParameterCamera::read(std::istream& is) {
 
 bool ParameterCamera::write(std::ostream& os) const {
   if (!internal::writeVector(os, internal::toVectorQT(_offset))) return false;
-  os << _Kcam(0, 0) << " "
-     << _Kcam(1, 1) << " "
-     << _Kcam(0, 2) << " "
+  os << _Kcam(0, 0) << " " << _Kcam(1, 1) << " " << _Kcam(0, 2) << " "
      << _Kcam(1, 2) << " ";
   return !os.fail();
 }

--- a/g2o/types/slam3d/parameter_camera.cpp
+++ b/g2o/types/slam3d/parameter_camera.cpp
@@ -62,24 +62,25 @@ void ParameterCamera::setKcam(double fx, double fy, double cx, double cy) {
 
 bool ParameterCamera::read(std::istream& is) {
   Vector7 off;
-  internal::readVector(is, off);
+  if (!internal::readVector(is, off)) return false;
   // normalize the quaternion to recover numerical precision lost by storing as
   // human readable text
   Vector4::MapType(off.data() + 3).normalize();
   setOffset(internal::fromVectorQT(off));
   double fx, fy, cx, cy;
   is >> fx >> fy >> cx >> cy;
+  if (is.fail()) return false;
   setKcam(fx, fy, cx, cy);
-  return is.good();
+  return true;
 }
 
 bool ParameterCamera::write(std::ostream& os) const {
-  internal::writeVector(os, internal::toVectorQT(_offset));
-  os << _Kcam(0, 0) << " ";
-  os << _Kcam(1, 1) << " ";
-  os << _Kcam(0, 2) << " ";
-  os << _Kcam(1, 2) << " ";
-  return os.good();
+  if (!internal::writeVector(os, internal::toVectorQT(_offset))) return false;
+  os << _Kcam(0, 0) << " "
+     << _Kcam(1, 1) << " "
+     << _Kcam(0, 2) << " "
+     << _Kcam(1, 2) << " ";
+  return !os.fail();
 }
 
 bool CacheCamera::resolveDependencies() {

--- a/g2o/types/slam3d/parameter_stereo_camera.cpp
+++ b/g2o/types/slam3d/parameter_stereo_camera.cpp
@@ -36,7 +36,7 @@ ParameterStereoCamera::ParameterStereoCamera()
 bool ParameterStereoCamera::read(std::istream& is) {
   bool state = ParameterCamera::read(is);
   is >> _baseline;
-  return is.good() && state;
+  return !is.fail() && state;
 }
 
 bool ParameterStereoCamera::write(std::ostream& os) const {

--- a/g2o/types/slam3d_addons/edge_se3_euler.cpp
+++ b/g2o/types/slam3d_addons/edge_se3_euler.cpp
@@ -57,6 +57,7 @@ static void jac_quat3_euler3(Eigen::Matrix<double, 6, 6, Eigen::ColMajor>& J,
 bool EdgeSE3Euler::read(std::istream& is) {
   Vector6 meas;
   for (int i = 0; i < 6; i++) is >> meas[i];
+  if (is.fail()) return false;
   Isometry3 transf = g2o::internal::fromVectorET(meas);
   Matrix<double, 6, 6, Eigen::ColMajor> infMatEuler;
   for (int i = 0; i < 6; i++)
@@ -64,6 +65,7 @@ bool EdgeSE3Euler::read(std::istream& is) {
       is >> infMatEuler(i, j);
       if (i != j) infMatEuler(j, i) = infMatEuler(i, j);
     }
+  if (is.fail()) return false;
   Matrix<double, 6, 6, Eigen::ColMajor> J;
   jac_quat3_euler3(J, transf);
   Matrix<double, 6, 6, Eigen::ColMajor> infMat =
@@ -87,7 +89,7 @@ bool EdgeSE3Euler::write(std::ostream& os) const {
     for (int j = i; j < 6; j++) {
       os << " " << infMatEuler(i, j);
     }
-  return os.good();
+  return !os.fail();
 }
 
 }  // namespace g2o

--- a/unit_test/general/CMakeLists.txt
+++ b/unit_test/general/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(unittest_general
   robust_kernel_tests.cpp
   sparse_block_matrix.cpp
   partially_initialize.cpp
+  io_truncated_input.cpp
 )
 target_link_libraries(unittest_general types_slam3d types_slam2d)
 create_test(unittest_general)

--- a/unit_test/general/io_truncated_input.cpp
+++ b/unit_test/general/io_truncated_input.cpp
@@ -44,8 +44,8 @@ TEST(IoTruncatedInput, CompleteRecordReadsSuccessfully) {
 
   EdgeSE2 in;
   ASSERT_TRUE(in.read(data));
-  EXPECT_TRUE(out.measurement().toVector().isApprox(
-      in.measurement().toVector(), 1e-9));
+  EXPECT_TRUE(
+      out.measurement().toVector().isApprox(in.measurement().toVector(), 1e-9));
   EXPECT_TRUE(out.information().isApprox(in.information(), 1e-9));
 }
 

--- a/unit_test/general/io_truncated_input.cpp
+++ b/unit_test/general/io_truncated_input.cpp
@@ -1,0 +1,80 @@
+// Tests that read() reports failure on incomplete input.
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "g2o/types/slam2d/edge_se2.h"
+#include "gtest/gtest.h"
+
+using namespace g2o;
+
+namespace {
+
+std::string truncatedRecord(const EdgeSE2& e, int dropTokens) {
+  std::stringstream full;
+  e.write(full);
+
+  std::istringstream iss(full.str());
+  std::vector<std::string> tokens;
+  for (std::string t; iss >> t;) tokens.push_back(t);
+
+  EXPECT_GT(static_cast<int>(tokens.size()), dropTokens)
+      << "test needs a record longer than the number of dropped tokens";
+
+  std::string out;
+  for (int i = 0; i + dropTokens < static_cast<int>(tokens.size()); ++i)
+    out += tokens[i] + " ";
+  return out;
+}
+
+void fillEdge(EdgeSE2& e) {
+  e.setMeasurement(SE2(1.0, 2.0, 0.3));
+  e.setInformation(Matrix3::Identity() * 7.0);
+}
+
+}  // namespace
+
+TEST(IoTruncatedInput, CompleteRecordReadsSuccessfully) {
+  EdgeSE2 out;
+  fillEdge(out);
+
+  std::stringstream data;
+  ASSERT_TRUE(out.write(data));
+
+  EdgeSE2 in;
+  ASSERT_TRUE(in.read(data));
+  EXPECT_TRUE(out.measurement().toVector().isApprox(
+      in.measurement().toVector(), 1e-9));
+  EXPECT_TRUE(out.information().isApprox(in.information(), 1e-9));
+}
+
+TEST(IoTruncatedInput, TruncatedInformationMatrixIsRejected) {
+  EdgeSE2 out;
+  fillEdge(out);
+  std::stringstream data(truncatedRecord(out, 3));
+
+  EdgeSE2 in;
+  in.setInformation(Matrix3::Zero());
+  EXPECT_FALSE(in.read(data))
+      << "read() accepted a record whose information matrix was cut short; "
+         "the element would be kept with a singular information matrix";
+}
+
+TEST(IoTruncatedInput, TruncatedMeasurementIsRejected) {
+  EdgeSE2 out;
+  fillEdge(out);
+  // An EdgeSE2 record is 3 measurement values + 6 upper-triangular
+  // information values; dropping 7 leaves the measurement incomplete.
+  std::stringstream data(truncatedRecord(out, 7));
+
+  EdgeSE2 in;
+  EXPECT_FALSE(in.read(data))
+      << "read() accepted a record whose measurement was cut short";
+}
+
+TEST(IoTruncatedInput, EmptyStreamIsRejected) {
+  std::stringstream data("");
+  EdgeSE2 in;
+  EXPECT_FALSE(in.read(data)) << "read() accepted an empty record";
+}


### PR DESCRIPTION
The serialization code used a mix of ways to figure out if a stream was in a good condition using the isotream.good() method. However, since good() can get confounded with EOF, is.good() || is.eof() is inconsistently used throughout the code. Furthermore, many of the i/o methods consist of operating on a state vector and then on an information matrix. If operations on the state vector fail, attempts are still made to serialize the information matrix. Some methods do not check the stream state at all and always return true.

This change makes the serialization code more robust and consistent. !iostream.fail() is used everywhere because this only trips on failure-related bits, not EOF. If the state vector operation fails, no attempt is made to serialize the information matrices. All return types are checked and returned.

A unit test is provided to check robustness to corrupted input.

Tag-teamed between the author and Claude.