### PR TITLE
Serialize missing fields. Use more robust serialization.

### DIFF
--- a/g2o/core/io_helper.h
+++ b/g2o/core/io_helper.h
@@ -29,6 +29,8 @@
 
 #include <Eigen/Core>
 #include <iosfwd>
+#include <istream>
+#include <string>
 
 namespace g2o {
 namespace internal {
@@ -41,6 +43,39 @@ bool writeVector(std::ostream& os, const Eigen::DenseBase<Derived>& b) {
 template <typename Derived>
 bool readVector(std::istream& is, Eigen::DenseBase<Derived>& b) {
   for (int i = 0; i < b.size() && !is.fail(); i++) is >> b(i);
+  return !is.fail();
+}
+
+/**
+ * @brief Whether the current line holds another token.
+ *
+ * Consumes blanks up to the first non-blank character. Deliberately stops at
+ * the end of the line: std::ws would consume the newline as well and let the
+ * optional trailing fields of one record steal the tokens of the next one. A
+ * trailing '\r' (CRLF input) counts as end of line.
+ */
+inline bool hasDataOnLine(std::istream& is) {
+  using Traits = std::char_traits<char>;
+  Traits::int_type c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  return c != '\n' && c != '\r' && !Traits::eq_int_type(c, Traits::eof());
+}
+
+/**
+ * @brief Read optional trailing fields of a record.
+ *
+ * If the line ends here the fields are left untouched, so records written by
+ * an older version of g2o keep whatever the constructor (or the caller) set.
+ * Otherwise the fields are all-or-nothing: a short or garbled tail is an
+ * error.
+ */
+template <typename... Ts>
+bool readOptional(std::istream& is, Ts&... fields) {
+  if (!hasDataOnLine(is)) return true;
+  (is >> ... >> fields);
   return !is.fail();
 }
 }  // namespace internal

--- a/g2o/types/sba/edge_project_stereo_xyz.cpp
+++ b/g2o/types/sba/edge_project_stereo_xyz.cpp
@@ -42,13 +42,27 @@ Vector3 EdgeStereoSE3ProjectXYZ::cam_project(const Vector3& trans_xyz,
 }
 
 bool EdgeStereoSE3ProjectXYZ::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  return readInformationMatrix(is);
+  if (!internal::readVector(is, _measurement)) return false;
+  if (!readInformationMatrix(is)) return false;
+
+  // Optional trailing camera intrinsics (fx, fy, cx, cy, bf). Legacy
+  // files that omit these keep the default values set at construction
+  // time.
+  int c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  if (c == '\n' || c == '\r' || c == EOF) return true;
+  is >> fx >> fy >> cx >> cy >> bf;
+  return !is.fail();
 }
 
 bool EdgeStereoSE3ProjectXYZ::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  return writeInformationMatrix(os);
+  if (!internal::writeVector(os, measurement())) return false;
+  if (!writeInformationMatrix(os)) return false;
+  os << " " << fx << " " << fy << " " << cx << " " << cy << " " << bf;
+  return !os.fail();
 }
 
 void EdgeStereoSE3ProjectXYZ::linearizeOplus() {

--- a/g2o/types/sba/edge_project_stereo_xyz.cpp
+++ b/g2o/types/sba/edge_project_stereo_xyz.cpp
@@ -48,14 +48,7 @@ bool EdgeStereoSE3ProjectXYZ::read(std::istream& is) {
   // Optional trailing camera intrinsics (fx, fy, cx, cy, bf). Legacy
   // files that omit these keep the default values set at construction
   // time.
-  int c = is.peek();
-  while (c == ' ' || c == '\t') {
-    is.get();
-    c = is.peek();
-  }
-  if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> fx >> fy >> cx >> cy >> bf;
-  return !is.fail();
+  return internal::readOptional(is, fx, fy, cx, cy, bf);
 }
 
 bool EdgeStereoSE3ProjectXYZ::write(std::ostream& os) const {

--- a/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
@@ -36,14 +36,7 @@ bool EdgeStereoSE3ProjectXYZOnlyPose::read(std::istream& is) {
   // intrinsics (fx, fy, cx, cy, bf). Legacy files that omit these keep
   // whatever was set on the edge at construction time (typically by
   // the caller).
-  int c = is.peek();
-  while (c == ' ' || c == '\t') {
-    is.get();
-    c = is.peek();
-  }
-  if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> Xw[0] >> Xw[1] >> Xw[2] >> fx >> fy >> cx >> cy >> bf;
-  return !is.fail();
+  return internal::readOptional(is, Xw[0], Xw[1], Xw[2], fx, fy, cx, cy, bf);
 }
 
 bool EdgeStereoSE3ProjectXYZOnlyPose::write(std::ostream& os) const {

--- a/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
@@ -29,13 +29,30 @@
 namespace g2o {
 
 bool EdgeStereoSE3ProjectXYZOnlyPose::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  return readInformationMatrix(is);
+  if (!internal::readVector(is, _measurement)) return false;
+  if (!readInformationMatrix(is)) return false;
+
+  // Optional trailing fields: world-frame landmark Xw and camera
+  // intrinsics (fx, fy, cx, cy, bf). Legacy files that omit these keep
+  // whatever was set on the edge at construction time (typically by
+  // the caller).
+  int c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  if (c == '\n' || c == '\r' || c == EOF) return true;
+  is >> Xw[0] >> Xw[1] >> Xw[2]
+     >> fx >> fy >> cx >> cy >> bf;
+  return !is.fail();
 }
 
 bool EdgeStereoSE3ProjectXYZOnlyPose::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  return writeInformationMatrix(os);
+  if (!internal::writeVector(os, measurement())) return false;
+  if (!writeInformationMatrix(os)) return false;
+  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2]
+     << " " << fx << " " << fy << " " << cx << " " << cy << " " << bf;
+  return !os.fail();
 }
 
 void EdgeStereoSE3ProjectXYZOnlyPose::linearizeOplus() {

--- a/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_stereo_xyz_onlypose.cpp
@@ -42,16 +42,15 @@ bool EdgeStereoSE3ProjectXYZOnlyPose::read(std::istream& is) {
     c = is.peek();
   }
   if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> Xw[0] >> Xw[1] >> Xw[2]
-     >> fx >> fy >> cx >> cy >> bf;
+  is >> Xw[0] >> Xw[1] >> Xw[2] >> fx >> fy >> cx >> cy >> bf;
   return !is.fail();
 }
 
 bool EdgeStereoSE3ProjectXYZOnlyPose::write(std::ostream& os) const {
   if (!internal::writeVector(os, measurement())) return false;
   if (!writeInformationMatrix(os)) return false;
-  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2]
-     << " " << fx << " " << fy << " " << cx << " " << cy << " " << bf;
+  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2] << " " << fx << " " << fy
+     << " " << cx << " " << cy << " " << bf;
   return !os.fail();
 }
 

--- a/g2o/types/sba/edge_project_xyz.cpp
+++ b/g2o/types/sba/edge_project_xyz.cpp
@@ -32,13 +32,26 @@ EdgeSE3ProjectXYZ::EdgeSE3ProjectXYZ()
     : BaseBinaryEdge<2, Vector2, VertexPointXYZ, VertexSE3Expmap>() {}
 
 bool EdgeSE3ProjectXYZ::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  return readInformationMatrix(is);
+  if (!internal::readVector(is, _measurement)) return false;
+  if (!readInformationMatrix(is)) return false;
+
+  // Optional trailing camera intrinsics (fx, fy, cx, cy). Legacy files
+  // that omit these keep the default values set at construction time.
+  int c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  if (c == '\n' || c == '\r' || c == EOF) return true;
+  is >> fx >> fy >> cx >> cy;
+  return !is.fail();
 }
 
 bool EdgeSE3ProjectXYZ::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  return writeInformationMatrix(os);
+  if (!internal::writeVector(os, measurement())) return false;
+  if (!writeInformationMatrix(os)) return false;
+  os << " " << fx << " " << fy << " " << cx << " " << cy;
+  return !os.fail();
 }
 
 void EdgeSE3ProjectXYZ::computeError() {

--- a/g2o/types/sba/edge_project_xyz.cpp
+++ b/g2o/types/sba/edge_project_xyz.cpp
@@ -37,14 +37,7 @@ bool EdgeSE3ProjectXYZ::read(std::istream& is) {
 
   // Optional trailing camera intrinsics (fx, fy, cx, cy). Legacy files
   // that omit these keep the default values set at construction time.
-  int c = is.peek();
-  while (c == ' ' || c == '\t') {
-    is.get();
-    c = is.peek();
-  }
-  if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> fx >> fy >> cx >> cy;
-  return !is.fail();
+  return internal::readOptional(is, fx, fy, cx, cy);
 }
 
 bool EdgeSE3ProjectXYZ::write(std::ostream& os) const {

--- a/g2o/types/sba/edge_project_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_xyz_onlypose.cpp
@@ -42,16 +42,15 @@ bool EdgeSE3ProjectXYZOnlyPose::read(std::istream& is) {
     c = is.peek();
   }
   if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> Xw[0] >> Xw[1] >> Xw[2]
-     >> fx >> fy >> cx >> cy;
+  is >> Xw[0] >> Xw[1] >> Xw[2] >> fx >> fy >> cx >> cy;
   return !is.fail();
 }
 
 bool EdgeSE3ProjectXYZOnlyPose::write(std::ostream& os) const {
   if (!internal::writeVector(os, measurement())) return false;
   if (!writeInformationMatrix(os)) return false;
-  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2]
-     << " " << fx << " " << fy << " " << cx << " " << cy;
+  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2] << " " << fx << " " << fy
+     << " " << cx << " " << cy;
   return !os.fail();
 }
 

--- a/g2o/types/sba/edge_project_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_xyz_onlypose.cpp
@@ -36,14 +36,7 @@ bool EdgeSE3ProjectXYZOnlyPose::read(std::istream& is) {
   // intrinsics (fx, fy, cx, cy). Legacy files that omit these keep
   // whatever was set on the edge at construction time (typically by
   // the caller).
-  int c = is.peek();
-  while (c == ' ' || c == '\t') {
-    is.get();
-    c = is.peek();
-  }
-  if (c == '\n' || c == '\r' || c == EOF) return true;
-  is >> Xw[0] >> Xw[1] >> Xw[2] >> fx >> fy >> cx >> cy;
-  return !is.fail();
+  return internal::readOptional(is, Xw[0], Xw[1], Xw[2], fx, fy, cx, cy);
 }
 
 bool EdgeSE3ProjectXYZOnlyPose::write(std::ostream& os) const {

--- a/g2o/types/sba/edge_project_xyz_onlypose.cpp
+++ b/g2o/types/sba/edge_project_xyz_onlypose.cpp
@@ -29,13 +29,30 @@
 namespace g2o {
 
 bool EdgeSE3ProjectXYZOnlyPose::read(std::istream& is) {
-  internal::readVector(is, _measurement);
-  return readInformationMatrix(is);
+  if (!internal::readVector(is, _measurement)) return false;
+  if (!readInformationMatrix(is)) return false;
+
+  // Optional trailing fields: world-frame landmark Xw and camera
+  // intrinsics (fx, fy, cx, cy). Legacy files that omit these keep
+  // whatever was set on the edge at construction time (typically by
+  // the caller).
+  int c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  if (c == '\n' || c == '\r' || c == EOF) return true;
+  is >> Xw[0] >> Xw[1] >> Xw[2]
+     >> fx >> fy >> cx >> cy;
+  return !is.fail();
 }
 
 bool EdgeSE3ProjectXYZOnlyPose::write(std::ostream& os) const {
-  internal::writeVector(os, measurement());
-  return writeInformationMatrix(os);
+  if (!internal::writeVector(os, measurement())) return false;
+  if (!writeInformationMatrix(os)) return false;
+  os << " " << Xw[0] << " " << Xw[1] << " " << Xw[2]
+     << " " << fx << " " << fy << " " << cx << " " << cy;
+  return !os.fail();
 }
 
 void EdgeSE3ProjectXYZOnlyPose::linearizeOplus() {

--- a/g2o/types/sim3/types_seven_dof_expmap.cpp
+++ b/g2o/types/sim3/types_seven_dof_expmap.cpp
@@ -65,22 +65,12 @@ bool VertexSim3Expmap::read(std::istream& is) {
   if (!internal::readVector(is, _principle_point1)) return false;
   setEstimate(Sim3(cam2world).inverse());
 
-  // Optional trailing fields added later: focal_length2, principle_point2,
-  // and an integer fix_scale flag. Skip inline whitespace but stop at
-  // newline / EOF so legacy single-line records (with only
-  // focal_length1 / principle_point1) still parse correctly.
-  int c = is.peek();
-  while (c == ' ' || c == '\t') {
-    is.get();
-    c = is.peek();
-  }
-  if (c == '\n' || c == '\r' || c == EOF) return true;
-  if (!internal::readVector(is, _focal_length2)) return false;
-  if (!internal::readVector(is, _principle_point2)) return false;
-  int fixScale = 0;
-  is >> fixScale;
-  _fix_scale = (fixScale != 0);
-  return !is.fail();
+  // Optional trailing fields added later: focal_length2, principle_point2
+  // and the fix_scale flag. Records written before they existed end here
+  // and keep the values they were constructed with.
+  return internal::readOptional(is, _focal_length2[0], _focal_length2[1],
+                                _principle_point2[0], _principle_point2[1],
+                                _fix_scale);
 }
 
 bool VertexSim3Expmap::write(std::ostream& os) const {
@@ -91,7 +81,7 @@ bool VertexSim3Expmap::write(std::ostream& os) const {
   if (!internal::writeVector(os, _principle_point1)) return false;
   if (!internal::writeVector(os, _focal_length2)) return false;
   if (!internal::writeVector(os, _principle_point2)) return false;
-  os << (_fix_scale ? 1 : 0) << " ";
+  os << _fix_scale << " ";
   return !os.fail();
 }
 

--- a/g2o/types/sim3/types_seven_dof_expmap.cpp
+++ b/g2o/types/sim3/types_seven_dof_expmap.cpp
@@ -60,26 +60,44 @@ EdgeSim3::EdgeSim3()
 
 bool VertexSim3Expmap::read(std::istream& is) {
   Vector7 cam2world;
-  bool state = true;
-  state &= internal::readVector(is, cam2world);
-  state &= internal::readVector(is, _focal_length1);
-  state &= internal::readVector(is, _principle_point1);
+  if (!internal::readVector(is, cam2world)) return false;
+  if (!internal::readVector(is, _focal_length1)) return false;
+  if (!internal::readVector(is, _principle_point1)) return false;
   setEstimate(Sim3(cam2world).inverse());
-  return state;
+
+  // Optional trailing fields added later: focal_length2, principle_point2,
+  // and an integer fix_scale flag. Skip inline whitespace but stop at
+  // newline / EOF so legacy single-line records (with only
+  // focal_length1 / principle_point1) still parse correctly.
+  int c = is.peek();
+  while (c == ' ' || c == '\t') {
+    is.get();
+    c = is.peek();
+  }
+  if (c == '\n' || c == '\r' || c == EOF) return true;
+  if (!internal::readVector(is, _focal_length2)) return false;
+  if (!internal::readVector(is, _principle_point2)) return false;
+  int fixScale = 0;
+  is >> fixScale;
+  _fix_scale = (fixScale != 0);
+  return !is.fail();
 }
 
 bool VertexSim3Expmap::write(std::ostream& os) const {
   Sim3 cam2world(estimate().inverse());
   Vector7 lv = cam2world.log();
-  internal::writeVector(os, lv);
-  internal::writeVector(os, _focal_length1);
-  internal::writeVector(os, _principle_point1);
-  return os.good();
+  if (!internal::writeVector(os, lv)) return false;
+  if (!internal::writeVector(os, _focal_length1)) return false;
+  if (!internal::writeVector(os, _principle_point1)) return false;
+  if (!internal::writeVector(os, _focal_length2)) return false;
+  if (!internal::writeVector(os, _principle_point2)) return false;
+  os << (_fix_scale ? 1 : 0) << " ";
+  return !os.fail();
 }
 
 bool EdgeSim3::read(std::istream& is) {
   Vector7 v7;
-  internal::readVector(is, v7);
+  if (!internal::readVector(is, v7)) return false;
   Sim3 cam2world(v7);
   setMeasurement(cam2world.inverse());
   return readInformationMatrix(is);
@@ -87,7 +105,7 @@ bool EdgeSim3::read(std::istream& is) {
 
 bool EdgeSim3::write(std::ostream& os) const {
   Sim3 cam2world(measurement().inverse());
-  internal::writeVector(os, cam2world.log());
+  if (!internal::writeVector(os, cam2world.log())) return false;
   return writeInformationMatrix(os);
 }
 
@@ -147,12 +165,12 @@ EdgeSim3ProjectXYZ::EdgeSim3ProjectXYZ()
     : BaseBinaryEdge<2, Vector2, VertexPointXYZ, VertexSim3Expmap>() {}
 
 bool EdgeSim3ProjectXYZ::read(std::istream& is) {
-  internal::readVector(is, _measurement);
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 
 bool EdgeSim3ProjectXYZ::write(std::ostream& os) const {
-  internal::writeVector(os, _measurement);
+  if (!internal::writeVector(os, _measurement)) return false;
   return writeInformationMatrix(os);
 }
 
@@ -160,12 +178,12 @@ EdgeInverseSim3ProjectXYZ::EdgeInverseSim3ProjectXYZ()
     : BaseBinaryEdge<2, Vector2, VertexPointXYZ, VertexSim3Expmap>() {}
 
 bool EdgeInverseSim3ProjectXYZ::read(std::istream& is) {
-  internal::readVector(is, _measurement);
+  if (!internal::readVector(is, _measurement)) return false;
   return readInformationMatrix(is);
 }
 
 bool EdgeInverseSim3ProjectXYZ::write(std::ostream& os) const {
-  internal::writeVector(os, _measurement);
+  if (!internal::writeVector(os, _measurement)) return false;
   return writeInformationMatrix(os);
 }
 

--- a/unit_test/sba/io_six_dof_expmap.cpp
+++ b/unit_test/sba/io_six_dof_expmap.cpp
@@ -25,6 +25,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "g2o/types/sba/types_six_dof_expmap.h"
 #include "gtest/gtest.h"
@@ -117,4 +119,138 @@ TEST_F(IoSixDofExpmapParam, ReadWriteEdgeProjectXYZ2UVU) {
   EdgeProjectXYZ2UVU* outputEdge = new EdgeProjectXYZ2UVU;
   prepareEdge(outputEdge);
   readWriteVectorBasedEdge<EdgeProjectXYZ2UVU>(outputEdge);
+}
+
+/*
+ * Optional trailing fields
+ *
+ * The camera intrinsics (and, for the OnlyPose edges, the world-frame
+ * landmark) were added to the record after the fact. Files written before
+ * that must still read, and a record that stops early must not swallow the
+ * tokens of the following line.
+ */
+namespace {
+
+// Serialize e and drop the last dropTokens tokens, emulating a record
+// written by a version of g2o that did not know about those fields.
+template <typename EdgeType>
+std::string recordWithoutLastTokens(const EdgeType& e, int dropTokens) {
+  std::stringstream full;
+  e.write(full);
+
+  std::istringstream iss(full.str());
+  std::vector<std::string> tokens;
+  for (std::string t; iss >> t;) tokens.push_back(t);
+
+  EXPECT_GT(static_cast<int>(tokens.size()), dropTokens)
+      << "test needs a record longer than the number of dropped tokens";
+
+  std::string out;
+  for (int i = 0; i + dropTokens < static_cast<int>(tokens.size()); ++i)
+    out += tokens[i] + " ";
+  return out;
+}
+
+void fillProjectXYZ(EdgeSE3ProjectXYZ& e) {
+  e.setMeasurement(Vector2(1., 2.));
+  e.setInformation(Matrix2::Identity() * 3.);
+  e.fx = 100.;
+  e.fy = 200.;
+  e.cx = 300.;
+  e.cy = 400.;
+}
+
+}  // namespace
+
+TEST(IoSixDofExpmap, EdgeSE3ProjectXYZRoundTripsIntrinsics) {
+  EdgeSE3ProjectXYZ out;
+  fillProjectXYZ(out);
+
+  std::stringstream data;
+  ASSERT_TRUE(out.write(data));
+
+  EdgeSE3ProjectXYZ in;
+  ASSERT_TRUE(in.read(data));
+  EXPECT_DOUBLE_EQ(out.fx, in.fx);
+  EXPECT_DOUBLE_EQ(out.fy, in.fy);
+  EXPECT_DOUBLE_EQ(out.cx, in.cx);
+  EXPECT_DOUBLE_EQ(out.cy, in.cy);
+}
+
+TEST(IoSixDofExpmap, EdgeSE3ProjectXYZReadsRecordWithoutIntrinsics) {
+  EdgeSE3ProjectXYZ out;
+  fillProjectXYZ(out);
+  std::stringstream data(recordWithoutLastTokens(out, 4));
+
+  EdgeSE3ProjectXYZ in;
+  in.fx = 7.;
+  in.fy = 8.;
+  in.cx = 9.;
+  in.cy = 10.;
+  ASSERT_TRUE(in.read(data)) << "record without intrinsics was rejected";
+  EXPECT_TRUE(out.measurement().isApprox(in.measurement(), 1e-9));
+  EXPECT_TRUE(out.information().isApprox(in.information(), 1e-9));
+  EXPECT_DOUBLE_EQ(7., in.fx) << "absent intrinsics must be left alone";
+  EXPECT_DOUBLE_EQ(8., in.fy);
+  EXPECT_DOUBLE_EQ(9., in.cx);
+  EXPECT_DOUBLE_EQ(10., in.cy);
+}
+
+TEST(IoSixDofExpmap, EdgeSE3ProjectXYZRejectsTruncatedIntrinsics) {
+  EdgeSE3ProjectXYZ out;
+  fillProjectXYZ(out);
+  std::stringstream data(recordWithoutLastTokens(out, 2));
+
+  EdgeSE3ProjectXYZ in;
+  EXPECT_FALSE(in.read(data))
+      << "read() accepted a record whose intrinsics were cut short";
+}
+
+TEST(IoSixDofExpmap, EdgeSE3ProjectXYZStopsAtEndOfLine) {
+  EdgeSE3ProjectXYZ out;
+  fillProjectXYZ(out);
+
+  std::stringstream data;
+  data << recordWithoutLastTokens(out, 4) << "\n"
+       << "NEXT_RECORD 11 12 13 14\n";
+
+  EdgeSE3ProjectXYZ in;
+  in.fx = 7.;
+  ASSERT_TRUE(in.read(data));
+  EXPECT_DOUBLE_EQ(7., in.fx)
+      << "read() took its intrinsics from the following line";
+
+  std::string token;
+  data >> token;
+  EXPECT_EQ("NEXT_RECORD", token) << "the following line was consumed";
+}
+
+TEST(IoSixDofExpmap, EdgeStereoSE3ProjectXYZOnlyPoseRoundTripsOptionalFields) {
+  EdgeStereoSE3ProjectXYZOnlyPose out;
+  out.setMeasurement(Vector3(1., 2., 3.));
+  out.setInformation(Matrix3::Identity() * 3.);
+  out.Xw = Vector3(4., 5., 6.);
+  out.fx = 100.;
+  out.fy = 200.;
+  out.cx = 300.;
+  out.cy = 400.;
+  out.bf = 500.;
+
+  std::stringstream data;
+  ASSERT_TRUE(out.write(data));
+
+  EdgeStereoSE3ProjectXYZOnlyPose in;
+  ASSERT_TRUE(in.read(data));
+  EXPECT_TRUE(out.Xw.isApprox(in.Xw, 1e-9));
+  EXPECT_DOUBLE_EQ(out.fx, in.fx);
+  EXPECT_DOUBLE_EQ(out.bf, in.bf);
+
+  // The same record without its optional tail leaves the edge untouched.
+  std::stringstream legacy(recordWithoutLastTokens(out, 8));
+  EdgeStereoSE3ProjectXYZOnlyPose legacyIn;
+  legacyIn.Xw = Vector3(7., 8., 9.);
+  legacyIn.bf = 11.;
+  ASSERT_TRUE(legacyIn.read(legacy));
+  EXPECT_TRUE(Vector3(7., 8., 9.).isApprox(legacyIn.Xw, 1e-9));
+  EXPECT_DOUBLE_EQ(11., legacyIn.bf);
 }

--- a/unit_test/sim3/io_sim3.cpp
+++ b/unit_test/sim3/io_sim3.cpp
@@ -25,6 +25,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "g2o/types/sim3/types_seven_dof_expmap.h"
 #include "gtest/gtest.h"
@@ -60,4 +62,85 @@ TEST(IoSim3, ReadWriteEdgeSim3ProjectXYZ) {
 
 TEST(IoSim3, ReadWriteEdgeInverseSim3ProjectXYZ) {
   readWriteVectorBasedEdge<EdgeInverseSim3ProjectXYZ>();
+}
+
+/*
+ * Optional trailing fields
+ *
+ * focal_length2, principle_point2 and the fix_scale flag were added to the
+ * record after the fact; vertices written before that must still read.
+ */
+namespace {
+
+// Serialize v and drop the last dropTokens tokens, emulating a record
+// written by a version of g2o that did not know about those fields.
+std::string recordWithoutLastTokens(const VertexSim3Expmap& v, int dropTokens) {
+  std::stringstream full;
+  v.write(full);
+
+  std::istringstream iss(full.str());
+  std::vector<std::string> tokens;
+  for (std::string t; iss >> t;) tokens.push_back(t);
+
+  EXPECT_GT(static_cast<int>(tokens.size()), dropTokens)
+      << "test needs a record longer than the number of dropped tokens";
+
+  std::string out;
+  for (int i = 0; i + dropTokens < static_cast<int>(tokens.size()); ++i)
+    out += tokens[i] + " ";
+  return out;
+}
+
+void fillVertex(VertexSim3Expmap& v) {
+  v.setEstimate(RandomSim3::create());
+  v._focal_length1 = Vector2(100., 200.);
+  v._principle_point1 = Vector2(300., 400.);
+  v._focal_length2 = Vector2(500., 600.);
+  v._principle_point2 = Vector2(700., 800.);
+  v._fix_scale = true;
+}
+
+}  // namespace
+
+TEST(IoSim3, VertexSim3ExpmapRoundTripsOptionalFields) {
+  VertexSim3Expmap out;
+  fillVertex(out);
+
+  std::stringstream data;
+  ASSERT_TRUE(out.write(data));
+
+  VertexSim3Expmap in;
+  ASSERT_TRUE(in.read(data));
+  EXPECT_TRUE(out._focal_length2.isApprox(in._focal_length2, 1e-9));
+  EXPECT_TRUE(out._principle_point2.isApprox(in._principle_point2, 1e-9));
+  EXPECT_TRUE(in._fix_scale);
+}
+
+TEST(IoSim3, VertexSim3ExpmapReadsRecordWithoutOptionalFields) {
+  VertexSim3Expmap out;
+  fillVertex(out);
+  // Drop focal_length2 (2), principle_point2 (2) and fix_scale (1).
+  std::stringstream data(recordWithoutLastTokens(out, 5));
+
+  VertexSim3Expmap in;
+  in._focal_length2 = Vector2(11., 12.);
+  in._principle_point2 = Vector2(13., 14.);
+  in._fix_scale = true;
+  ASSERT_TRUE(in.read(data)) << "record without optional fields was rejected";
+  EXPECT_TRUE(out._focal_length1.isApprox(in._focal_length1, 1e-9));
+  EXPECT_TRUE(out._principle_point1.isApprox(in._principle_point1, 1e-9));
+  EXPECT_TRUE(Vector2(11., 12.).isApprox(in._focal_length2, 1e-9));
+  EXPECT_TRUE(Vector2(13., 14.).isApprox(in._principle_point2, 1e-9));
+  EXPECT_TRUE(in._fix_scale) << "absent fix_scale flag must be left alone";
+}
+
+TEST(IoSim3, VertexSim3ExpmapRejectsTruncatedOptionalFields) {
+  VertexSim3Expmap out;
+  fillVertex(out);
+  // focal_length2 present, principle_point2 and fix_scale cut short.
+  std::stringstream data(recordWithoutLastTokens(out, 3));
+
+  VertexSim3Expmap in;
+  EXPECT_FALSE(in.read(data))
+      << "read() accepted a record whose optional fields were cut short";
 }


### PR DESCRIPTION
Hopefully the last change!

In the serialization code, some of the fields for some of the edges were not being serialized and, as a result, if you save and load the graph again, the loaded graph is missing some data. This pull request addresses this issue. There are two main parts:
1. Serialization for the missing fields is provided. The load() code supports the legacy format by simply skipping the fields if they aren't saved.
2. The more robust io (use of !is.fail(), etc) is added for those edge types. This should have been included as part of the last PR, but I had failed to sort out the files properly.

Author + Claude